### PR TITLE
tech :: Convert vue components to TypeScript

### DIFF
--- a/.storybook/bundle.ts
+++ b/.storybook/bundle.ts
@@ -1,0 +1,14 @@
+/*
+  This file creates the bundle needed by storybook to import the UI components.
+  All components available in the Storybook must be exported here.
+*/
+
+import DomainSelector from '../src/components/DomainSelector.vue'
+import Pipeline from '../src/components/Pipeline.vue'
+import Step from '../src/components/Step.vue'
+
+export {
+  DomainSelector,
+  Pipeline,
+  Step,
+}

--- a/.storybook/rollup.config.js
+++ b/.storybook/rollup.config.js
@@ -1,0 +1,13 @@
+import mainConfig from '../rollup.config'
+
+export default {
+  ...mainConfig,
+  input: '.storybook/bundle.ts',
+  output: [
+      {
+          file: 'dist/storybook/components.js',
+          format: 'esm'
+      }
+  ],
+}
+

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ generate the corresponding documentation in the `dist/docs` directory.
 
 ### Run the storybook
 
+> Storybook uses the bundled lib, so all showcased components must be in the public API.
+
+In one terminal:
+```bash
+yarn storybook:bundle --watch
+```
+
+In another:
 ```bash
 yarn storybook
 ```

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "typescript": "~3.1.1",
     "vue": "^2.6.8",
     "vue-class-component": "^6.0.0",
-    "vue-property-decorator": "^7.0.0",
     "vue-loader": "^15.7.0",
+    "vue-property-decorator": "^8.0.0",
     "vue-template-compiler": "^2.6.8"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,9 @@
     "lint": "vue-cli-service lint",
     "build-bundle": "rollup -c",
     "build-doc": "typedoc --readme README.md --out dist/docs src/",
-    "test:unit": "vue-cli-service test:unit",
-    "storybook": "start-storybook -p 9001 -c .storybook"
-  },
-  "peerDependencies": {
-    "vue": "2.x"
+    "storybook": "start-storybook -p 9001 -c .storybook",
+    "storybook:bundle": "rollup -c .storybook/rollup.config.js",
+    "test:unit": "vue-cli-service test:unit"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",
@@ -82,5 +80,8 @@
   ],
   "main": "dist/vue-query-builder.common.js",
   "module": "dist/vue-query-builder.esm.js",
+  "peerDependencies": {
+    "vue": "2.x"
+  },
   "sideeffects": false
 }

--- a/src/components/DomainSelector.vue
+++ b/src/components/DomainSelector.vue
@@ -24,7 +24,10 @@ import { Component, Prop } from 'vue-property-decorator'
   name: 'domain-selector'
 })
 export default class DomainSelector extends Vue {
-  @Prop({ default: () => [] })
+  @Prop({
+    default: () => [],
+    type: Array
+  })
   readonly domainsList!: Array<string>
 
   @Prop()

--- a/src/components/DomainSelector.vue
+++ b/src/components/DomainSelector.vue
@@ -16,22 +16,28 @@
   </div>
 </template>
 
-<script>
-export default {
-  name: 'domain-selector',
-  props: {
-    domainsList: Array,
-    selectedDomain: String,
-  },
-  methods: {
-    isDomainSelected(name) {
-      return this.selectedDomain === name;
-    },
-    select(newDomain) {
-      this.$emit('selectedDomain', newDomain);
-    },
-  },
-};
+<script lang="ts">
+import Vue from 'vue'
+import { Component, Prop } from 'vue-property-decorator'
+
+@Component({
+  name: 'domain-selector'
+})
+export default class DomainSelector extends Vue {
+  @Prop({ default: () => [] })
+  readonly domainsList!: Array<string>
+
+  @Prop()
+  readonly selectedDomain!: string | undefined
+
+  isDomainSelected(name: string) {
+    return this.selectedDomain === name;
+  }
+
+  select(newDomain: string) {
+    this.$emit('selectedDomain', newDomain);
+  }
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -25,73 +25,84 @@
     />
   </div>
 </template>
-<script>
-import DomainSelector from './DomainSelector.vue';
-import Step from './Step.vue';
 
-export default {
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component, Prop } from 'vue-property-decorator'
+
+import { PipelineStep } from '@/lib/steps'
+import DomainSelector from './DomainSelector.vue'
+import Step from './Step.vue'
+
+@Component({
   name: 'pipeline',
   components: {
     DomainSelector,
     Step,
   },
-  props: {
-    steps: Array,
-    domainsList: Array,
-  },
-  data() {
-    return {
-      selectedStep: -1,
-      activePipeline: [],
-      disabledPipeline: [],
-    };
-  },
-  computed: {
-    selectedIndex() {
-      if (this.selectedStep < 0) {
-        return this.stepsWithoutDomain.length -1;
-      }
+})
+export default class Pipeline extends Vue {
+  @Prop()
+  steps!: Array<PipelineStep>
 
-      return this.selectedStep;
-    },
-    isEmpty() {
-      return this.stepsWithoutDomain.length === 0;
-    },
-    stepDomain() {
-      return this.steps[0];
-    },
-    stepsWithoutDomain() {
-      return this.steps.slice(1).concat(this.disabledPipeline);
-    },
-  },
-  methods: {
-    isDisabled(index) {
-      if (this.selectedStep < 0) {
-        return false;
-      }
-      return index > this.selectedStep;
-    },
-    selectStep(index) {
-      let pipeline = [];
-      this.selectedStep = index;
+  @Prop()
+  domainsList!: Array<string>
 
-      this.activePipeline = this.stepsWithoutDomain.slice(0, this.selectedStep + 1);
+  selectedStep: number = -1
+  activePipeline: Array<PipelineStep> = []
+  disabledPipeline: Array<PipelineStep> = []
 
-      // Separate steps that are after the selected one to keep in memory
-      this.disabledPipeline = this.stepsWithoutDomain.slice(this.selectedStep + 1, this.stepsWithoutDomain.length);
+  get selectedIndex() {
+    if (this.selectedStep < 0) {
+      return this.stepsWithoutDomain.length -1
+    }
 
-      // We emit the active pipeline with the step 0 (select domain) to the parent
-      this.$emit('selectedPipeline', pipeline.concat(this.stepDomain, this.activePipeline));
-    },
-    resetSelectedStep() {
-      this.selectedStep = -1;
-    },
-    updateDomain(newDomain) {
-      return newDomain; // Emit an event
-    },
-  },
-};
+    return this.selectedStep
+  }
+
+  get isEmpty() {
+    return this.stepsWithoutDomain.length === 0
+  }
+
+  get stepDomain() {
+    return this.steps[0]
+  }
+
+  get stepsWithoutDomain() {
+    return this.steps.slice(1).concat(this.disabledPipeline)
+  }
+
+  isDisabled(index: number) {
+    if (this.selectedStep < 0) {
+      return false;
+    }
+    return index > this.selectedStep
+  }
+
+  selectStep(index: number) {
+    let pipeline: Array<PipelineStep> = []
+    this.selectedStep = index
+
+    this.activePipeline = this.stepsWithoutDomain.slice(0, this.selectedStep + 1)
+
+    // Separate steps that are after the selected one to keep in memory
+    this.disabledPipeline = this.stepsWithoutDomain.slice(this.selectedStep + 1, this.stepsWithoutDomain.length)
+
+    // We emit the active pipeline with the step 0 (select domain) to the parent
+    this.$emit('selectedPipeline', pipeline.concat(this.stepDomain, this.activePipeline))
+  }
+
+  resetSelectedStep() {
+    this.selectedStep = -1
+  }
+
+  updateDomain(newDomain: string) {
+    return newDomain // Emit an event
+  }
+}
 </script>
+
 <style lang="scss" scoped>
   @import '../styles/Pipeline';
 </style>

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -43,10 +43,10 @@ import Step from './Step.vue'
   },
 })
 export default class Pipeline extends Vue {
-  @Prop()
+  @Prop(Array)
   steps!: Array<PipelineStep>
 
-  @Prop()
+  @Prop(Array)
   domainsList!: Array<string>
 
   selectedStep: number = -1

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -30,16 +30,16 @@ import { PipelineStep } from '@/lib/steps'
   name: 'step'
 })
 export default class Step extends Vue {
-  @Prop({default: false})
+  @Prop(Boolean)
   readonly isFirst!: boolean
 
-  @Prop({default: false})
+  @Prop(Boolean)
   readonly isLast!: boolean
 
-  @Prop({default: false})
+  @Prop(Boolean)
   readonly isActive!: boolean
 
-  @Prop({default: false})
+  @Prop(Boolean)
   readonly isDisabled!: boolean
 
   @Prop()

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -23,26 +23,27 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import { PipelineStep } from '../lib/steps'
+
+import { PipelineStep } from '@/lib/steps'
 
 @Component({
   name: 'step'
 })
 export default class Step extends Vue {
-  @Prop()
-  isFirst: boolean = false
+  @Prop({default: false})
+  readonly isFirst!: boolean
+
+  @Prop({default: false})
+  readonly isLast!: boolean
+
+  @Prop({default: false})
+  readonly isActive!: boolean
+
+  @Prop({default: false})
+  readonly isDisabled!: boolean
 
   @Prop()
-  isLast: boolean = false
-
-  @Prop()
-  isActive: boolean = false
-
-  @Prop()
-  isDisabled: boolean = false
-
-  @Prop()
-  step: PipelineStep | undefined
+  step!: PipelineStep
 
   get classDot() {
     return {

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -20,64 +20,72 @@
     </div>
   </div>
 </template>
-<script>
+<script lang="ts">
 import Vue from 'vue'
+import { Component, Prop } from 'vue-property-decorator'
+import { PipelineStep } from '../lib/steps'
 
-export default Vue.extend({
-  name: 'step',
-  props: {
-    isFirst: Boolean,
-    isLast: Boolean,
-    isActive: {
-      type: Boolean,
-      default: false
-    },
-    isDisabled: {
-      type: Boolean,
-      default: false,
-    },
-    step: Object,
-  },
-  computed: {
-    classDot() {
-      return {
-        'query-pipeline-queue__dot': true,
-        'query-pipeline-queue__dot--active': this.isActive,
-        'query-pipeline-queue__dot--disabled': this.isDisabled,
-      };
-    },
-    classDotInk() {
-      return {
-        'query-pipeline-queue__dot-ink': true,
-        'query-pipeline-queue__dot-ink--active': this.isActive,
-        'query-pipeline-queue__dot-ink--disabled': this.isDisabled,
-      };
-    },
-    classStep() {
-      return {
-        'query-pipeline-step': true,
-        'query-pipeline-step--disabled': this.isDisabled,
-      }
-    },
-    firstStrokeClass() {
-      return {
-        'query-pipeline-queue__stroke': true,
-        'query-pipeline-queue__stroke--hidden': this.isFirst,
-      };
-    },
-    lastStrokeClass() {
+@Component({
+  name: 'step'
+})
+export default class Step extends Vue {
+  @Prop()
+  isFirst: boolean = false
+
+  @Prop()
+  isLast: boolean = false
+
+  @Prop()
+  isActive: boolean = false
+
+  @Prop()
+  isDisabled: boolean = false
+
+  @Prop()
+  step: PipelineStep | undefined
+
+  get classDot() {
+    return {
+      'query-pipeline-queue__dot': true,
+      'query-pipeline-queue__dot--active': this.isActive,
+      'query-pipeline-queue__dot--disabled': this.isDisabled,
+    };
+  }
+
+  get classDotInk() {
+    return {
+      'query-pipeline-queue__dot-ink': true,
+      'query-pipeline-queue__dot-ink--active': this.isActive,
+      'query-pipeline-queue__dot-ink--disabled': this.isDisabled,
+    };
+  }
+
+  get classStep() {
+    return {
+      'query-pipeline-step': true,
+      'query-pipeline-step--disabled': this.isDisabled,
+    }
+  }
+
+  get firstStrokeClass() {
+    return {
+      'query-pipeline-queue__stroke': true,
+      'query-pipeline-queue__stroke--hidden': this.isFirst,
+    };
+  }
+
+  get lastStrokeClass() {
       return {
         'query-pipeline-queue__stroke': true,
         'query-pipeline-queue__stroke--hidden': this.isLast,
       };
-    },
-  },
-  methods: {
-    select() {
-      this.$emit('selectedStep');
-    },
-  },
-});
+    }
+
+
+  select() {
+    this.$emit('selectedStep');
+  }
+}
 </script>
 <style lang="scss" scoped>
   @import '../styles/Steps';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 export { mongoToPipe, pipeToMongo } from './lib/pipeline';
-import Pipeline from './components/Pipeline.vue';
 
+import Pipeline from './components/Pipeline.vue';
 export { Pipeline };
+

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,4 +1,6 @@
-import Step from '../src/components/Step.vue';
+import { Step } from '../dist/storybook/components';
+import '../dist/vue-query-builder.css';
+
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 
 import { storiesOf } from '@storybook/vue';
@@ -25,7 +27,7 @@ stories.addDecorator(withKnobs)
         }
       }
     },
-    template: '<step isFirst :step="step"></step>'
+    template: '<step is-first :step="step"></step>'
   }))
 
   .add('last', () => ({
@@ -37,5 +39,5 @@ stories.addDecorator(withKnobs)
         }
       }
     },
-    template: '<step isLast :step="step"></step>'
+    template: '<step is-last :step="step"></step>'
   }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -12174,10 +12174,15 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vue-class-component@^6.0.0, vue-class-component@^6.2.0:
+vue-class-component@^6.0.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-6.3.2.tgz#e6037e84d1df2af3bde4f455e50ca1b9eec02be6"
   integrity sha512-cH208IoM+jgZyEf/g7mnFyofwPDJTM/QvBNhYMjqGB8fCsRyTf68rH2ISw/G20tJv+5mIThQ3upKwoL4jLTr1A==
+
+vue-class-component@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-7.0.1.tgz#7af2225c600667c7042b60712eefdf41dfc6de63"
+  integrity sha512-YIihdl7YmceEOjSwcxLhCXCNA3TKC2FStuMcjtuzhUAgw5x5d1T5gZTmVQHGyOaQsaKffL4GlZzYN3dlMYl53w==
 
 vue-eslint-parser@^2.0.3:
   version "2.0.3"
@@ -12235,12 +12240,12 @@ vue-loader@^15.6.4, vue-loader@^15.7.0:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
-vue-property-decorator@^7.0.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-7.3.0.tgz#d50d67f0b0f1c814f9f2fba36d6eeccbcc62dbb6"
-  integrity sha512-HarXfTQ/Nxm4s/APpAaGIGHq5ZzslApImQy8ZrtkfGamw8rUFAVgMS5C50/AQ80+wfw3Wpnf4bNzbmj75m/k2Q==
+vue-property-decorator@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-8.0.0.tgz#a2e9bb2419b638cbf1614e17b99aa675d6d4e9e4"
+  integrity sha512-aaAO/Wbh+n3sPMOoQ+Rwi9va6vFqZPX13dA8vMycGuS/DOIYC77KxX0gMAPEzzkT4Umya0uSlTvBV5jQvSTyBQ==
   dependencies:
-    vue-class-component "^6.2.0"
+    vue-class-component "^7.0.1"
 
 vue-runtime-helpers@1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,7 +1471,7 @@
     semver "^5.5.0"
     string.prototype.padstart "^3.0.0"
 
-"@vue/component-compiler-utils@^2.1.0", "@vue/component-compiler-utils@^2.5.1":
+"@vue/component-compiler-utils@^2.1.0", "@vue/component-compiler-utils@^2.5.1", "@vue/component-compiler-utils@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz#aa46d2a6f7647440b0b8932434d22f12371e543b"
   integrity sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==
@@ -1485,20 +1485,6 @@
     prettier "1.16.3"
     source-map "~0.6.1"
     vue-template-es2015-compiler "^1.9.0"
-
-"@vue/component-compiler-utils@^2.4.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-2.5.0.tgz#411846d582d393f701f747517ddd29275ce64ca4"
-  dependencies:
-    consolidate "^0.15.1"
-    hash-sum "^1.0.2"
-    lru-cache "^4.1.2"
-    merge-source-map "^1.1.0"
-    postcss "^7.0.7"
-    postcss-selector-parser "^5.0.0"
-    prettier "1.13.7"
-    source-map "^0.7.3"
-    vue-template-es2015-compiler "^1.6.0"
 
 "@vue/component-compiler@^3.6":
   version "3.6.0"
@@ -1906,11 +1892,11 @@ acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3, acorn@^5.6.2:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^6.0.1, acorn@^6.0.2, acorn@^6.0.4:
+acorn@^6.0.1, acorn@^6.0.2:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.5.tgz#81730c0815f3f3b34d8efa95cb7430965f4d887a"
 
-acorn@^6.0.5, acorn@^6.1.1:
+acorn@^6.0.5, acorn@^6.0.7, acorn@^6.1.0, acorn@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
@@ -5661,6 +5647,7 @@ gaze@^1.0.0:
   integrity sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==
   dependencies:
     globule "^1.0.0"
+
 generic-names@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-1.0.3.tgz#2d786a121aee508876796939e8e3bff836c20917"
@@ -7294,20 +7281,10 @@ joi@^14.3.0:
     isemail "3.x.x"
     topo "3.x.x"
 
-js-base64@^2.1.9:
+js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
   integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
-
-js-beautify@^1.6.12, js-beautify@^1.6.14:
-  version "1.8.9"
-  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.8.9.tgz#08e3c05ead3ecfbd4f512c3895b1cda76c87d523"
-  dependencies:
-    config-chain "^1.1.12"
-    editorconfig "^0.15.2"
-    glob "^7.1.3"
-    mkdirp "~0.5.0"
-    nopt "~4.0.1"
 
 js-beautify@^1.6.12, js-beautify@^1.6.14, js-beautify@^1.8.9:
   version "1.9.0"
@@ -11027,22 +11004,22 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.6.*, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@0.7.3, source-map@^0.7.2:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
 source-map@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
   dependencies:
     amdefine ">=0.0.4"
-
-source-map@0.6.*, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-source-map@0.7.3, source-map@^0.7.2, source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"


### PR DESCRIPTION
So we can benefit from type checking inside vue components.

Docs to learn how to use these decorators and class syntax:
- https://vuejs.org/v2/guide/typescript.html
- https://github.com/vuejs/vue-class-component
- https://github.com/kaorun343/vue-property-decorator

Note: storybook now uses a specific bundle, also built with the same rollup configuration.
It's therefore needed to export any component to showcase in `.storybook/bundle.ts`.