### PR TITLE
[pipeline] naive implementation of aggregate step

### DIFF
--- a/doc/steps.md
+++ b/doc/steps.md
@@ -80,6 +80,27 @@ Compute a new column based on another one or a custom query.
 }
 ```
 
+### `aggregate` step
+
+Perform aggregations on one or several columns.
+
+An aggreation step has the following strucure:
+
+```javascript
+{
+   name: 'aggregate',
+   on: ['column1', 'column2'],
+   aggregations:  [
+      {
+          name: 'sum_value1'
+          operation: 'sum'
+          column: 'value1',
+      }
+    // ...
+  ]
+}
+```
+
 ### 'custom' step
 
 This step allows to define a custom query that can't be expressed using the

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -36,6 +36,23 @@ export interface NewColumnStep {
   query: object | string;
 }
 
+interface AggFunctionStep {
+  /** name of the agg function step, (typically the name of the output column) */
+  name: string;
+  /** the aggregation operation (e.g. `sum` or `count`) */
+  aggfunction: string;
+  /** the column the aggregation function is working on */
+  column: string;
+}
+
+export interface AggregationStep {
+  name: 'aggregate';
+  /** the list columns we want to aggregate on */
+  on: Array<string>;
+  /** the list of aggregation operations to perform */
+  aggregations: Array<AggFunctionStep>;
+}
+
 export interface CustomStep {
   name: 'custom';
   query: object;
@@ -48,4 +65,5 @@ export type PipelineStep =
   | RenameStep
   | DeleteStep
   | NewColumnStep
+  | AggregationStep
   | CustomStep;


### PR DESCRIPTION
An aggreation step has the following strucure:

```javascript
{
   name: 'aggregate',
   on: ['column1', 'column2'],
   aggregations:  [
      {
          name: 'sum_value1'
          operation: 'sum'
          column: 'value1',
      }
    // ...
  ]
}
```

This will group by `column1` and `column2` then perform a sum on the
column `value1`. The output will be stored in the `sum_value` column.

Closes #57