### PR TITLE
feature :: translator toolchain

### DIFF
--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -1,0 +1,70 @@
+/**
+ * This module provides the basic type machinery to build pipeline
+ * translators efficiently and safely.
+ *
+ * It exposes 2 main building blocks:
+ * - `StepMatcher`: a type mapping each available pipeline steps to a
+ *   translation function
+ * - `matchStep`: a function accepting a `StepMatcher` and that return a function
+ *   transforming a pipeline step to an arbiratry output.
+ *
+ * This system is supposed to be typesafe, which means that if you add a
+ * new type of `PipelineStep`, the typescript compiler is expected to fail
+ * if your matcher implementation doesn't provide a mapping for this new kind
+ * of step.
+ */
+import { PipelineStep, PipelineStepName } from './steps';
+
+/**
+ * `StepByType` is a conditional type that expects the `PipelineStep` type and
+ * a valid step name and return the only possible step type matching this name.
+ *
+ * For instance, `StepByType<PipelineStep, 'delete'>` is equivalent to `DeleteStep`
+ */
+export type StepByType<A, T> = A extends { name: T } ? A : never;
+
+/**
+ * `StepMatcher` is a type built dynamically according to each available step
+ * name that associates each of this step name to a specific processing function
+ * accepting a step of corresponding type. For instance, it will generate the
+ * `rename: (step: RenameStep) => T` mapping entry automatically.
+ *
+ * This type will help to enforce that each kind of step has a corresponding
+ * translation function at compile time.
+ */
+export type StepMatcher<T> = { [K in PipelineStepName]: (step: StepByType<PipelineStep, K>) => T };
+
+/**
+ * Helper exception to handle unreachable conditions in a switch statement.
+ * This will help the typescript compiler to raise an error if one or several
+ * kind of steps are missing in a switch / case statement.
+ *
+ */
+class Unreachable extends Error {
+  constructor(value: never) {
+    super(`value ${value} is not valid`);
+  }
+}
+
+export function matchStep<T>(matcher: StepMatcher<T>): (step: PipelineStep) => T {
+  return (step: PipelineStep): T => {
+    switch (step.name) {
+      case 'domain':
+        return matcher.domain(step);
+      case 'filter':
+        return matcher.filter(step);
+      case 'select':
+        return matcher.select(step);
+      case 'rename':
+        return matcher.rename(step);
+      case 'delete':
+        return matcher.delete(step);
+      case 'newcolumn':
+        return matcher.newcolumn(step);
+      case 'custom':
+        return matcher.custom(step);
+      default:
+        throw new Unreachable(step);
+    }
+  };
+}

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -5,13 +5,7 @@
  */
 
 import { PipelineStep } from './steps';
-
-/**
- * MongoStep interface. For now, it's basically an object with any property.
- */
-export interface MongoStep {
-  [propName: string]: any;
-}
+import { MongoStep } from '@/lib/translators/mongo';
 
 /**
  * Transform a mongo `$match` step into a list of pipeline steps.
@@ -110,81 +104,4 @@ export function mongoToPipe(mongoSteps: Array<MongoStep>): Array<PipelineStep> {
     listOfSteps.push(...transformer(step));
   }
   return listOfSteps;
-}
-
-/**
- * Transform a standard pipeline into a list of mongo steps.
- *
- * - 'domain' steps are transformed into `$match` statements,
- * - 'select', 'rename', 'delete' and 'newcolumn' steps are transformed into
- *   `$project` statements,
- * - 'filter' steps are transformed into `match` statements.
- *
- * @param pipeline the input pipeline
- *
- * @returns the list of corresponding mongo steps
- */
-export function pipeToMongo(pipeline: Array<PipelineStep>): Array<MongoStep> {
-  const mongoSteps: Array<MongoStep> = [];
-  for (const step of pipeline) {
-    if (step.name === 'domain') {
-      mongoSteps.push({ $match: { domain: step.domain } });
-    } else if (step.name === 'select') {
-      const projection: { [propName: string]: number } = {};
-      for (const column of step.columns) {
-        projection[column] = 1;
-      }
-      mongoSteps.push({ $project: projection });
-    } else if (step.name === 'rename') {
-      mongoSteps.push({ $project: { [step.newname]: `$${step.oldname}` } });
-    } else if (step.name === 'delete') {
-      const projection: { [propName: string]: number } = {};
-      for (const column of step.columns) {
-        projection[column] = 0;
-      }
-      mongoSteps.push({ $project: projection });
-    } else if (step.name === 'filter') {
-      if (step.operator === undefined || step.operator === 'eq') {
-        mongoSteps.push({ $match: { [step.column]: step.value } });
-      } else {
-        throw new Error(`Operator ${step.operator} is not handled yet.`);
-      }
-    } else if (step.name === 'newcolumn') {
-      mongoSteps.push({ $project: { [step.column]: step.query } });
-    } else if (step.name === 'custom') {
-      mongoSteps.push(step.query);
-    }
-  }
-  return simplifyMongoPipeline(mongoSteps);
-}
-
-/**
- * Simplify a list of mongo steps (i.e. merge them whenever possible)
- *
- * - if multiple `$match` steps are chained, merge them,
- * - if multiple `$project` steps are chained, merge them.
- *
- * @param mongoSteps the input pipeline
- *
- * @returns the list of simplified mongo steps
- */
-function simplifyMongoPipeline(mongoSteps: Array<MongoStep>): Array<MongoStep> {
-  const outputSteps: Array<MongoStep> = [];
-  let lastStep: MongoStep = mongoSteps[0];
-  outputSteps.push(lastStep);
-
-  for (const step of mongoSteps.slice(1)) {
-    if (step.$project !== undefined && lastStep.$project !== undefined) {
-      // merge $project steps together
-      lastStep.$project = { ...lastStep.$project, ...step.$project };
-      continue;
-    } else if (step.$match !== undefined && lastStep.$match !== undefined) {
-      // merge $match steps together
-      lastStep.$match = { ...lastStep.$match, ...step.$match };
-      continue;
-    }
-    lastStep = step;
-    outputSteps.push(lastStep);
-  }
-  return outputSteps;
 }

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -49,3 +49,5 @@ export type PipelineStep =
   | DeleteStep
   | NewColumnStep
   | CustomStep;
+
+export type PipelineStepName = PipelineStep['name'];

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -1,0 +1,91 @@
+/** This module contains mongo specific translation operations */
+
+import { PipelineStep } from '@/lib/steps';
+
+/**
+ * MongoStep interface. For now, it's basically an object with any property.
+ */
+export interface MongoStep {
+  [propName: string]: any;
+}
+
+/**
+ * Transform a standard pipeline into a list of mongo steps.
+ *
+ * - 'domain' steps are transformed into `$match` statements,
+ * - 'select', 'rename', 'delete' and 'newcolumn' steps are transformed into
+ *   `$project` statements,
+ * - 'filter' steps are transformed into `match` statements.
+ *
+ * @param pipeline the input pipeline
+ *
+ * @returns the list of corresponding mongo steps
+ */
+export function pipeToMongo(pipeline: Array<PipelineStep>): Array<MongoStep> {
+  const mongoSteps: Array<MongoStep> = [];
+  for (const step of pipeline) {
+    if (step.name === 'domain') {
+      mongoSteps.push({ $match: { domain: step.domain } });
+    } else if (step.name === 'select') {
+      const projection: { [propName: string]: number } = {};
+      for (const column of step.columns) {
+        projection[column] = 1;
+      }
+      mongoSteps.push({ $project: projection });
+    } else if (step.name === 'rename') {
+      mongoSteps.push({ $project: { [step.newname]: `$${step.oldname}` } });
+    } else if (step.name === 'delete') {
+      const projection: { [propName: string]: number } = {};
+      for (const column of step.columns) {
+        projection[column] = 0;
+      }
+      mongoSteps.push({ $project: projection });
+    } else if (step.name === 'filter') {
+      if (step.operator === undefined || step.operator === 'eq') {
+        mongoSteps.push({ $match: { [step.column]: step.value } });
+      } else {
+        throw new Error(`Operator ${step.operator} is not handled yet.`);
+      }
+    } else if (step.name === 'newcolumn') {
+      mongoSteps.push({ $project: { [step.column]: step.query } });
+    } else if (step.name === 'custom') {
+      mongoSteps.push(step.query);
+    }
+  }
+  return simplifyMongoPipeline(mongoSteps);
+}
+
+/**
+ * Simplify a list of mongo steps (i.e. merge them whenever possible)
+ *
+ * - if multiple `$match` steps are chained, merge them,
+ * - if multiple `$project` steps are chained, merge them.
+ *
+ * @param mongoSteps the input pipeline
+ *
+ * @returns the list of simplified mongo steps
+ */
+function simplifyMongoPipeline(mongoSteps: Array<MongoStep>): Array<MongoStep> {
+  const outputSteps: Array<MongoStep> = [];
+  let lastStep: MongoStep = mongoSteps[0];
+  outputSteps.push(lastStep);
+
+  for (const step of mongoSteps.slice(1)) {
+    if (step.$project !== undefined && lastStep.$project !== undefined) {
+      // merge $project steps together
+      lastStep.$project = { ...lastStep.$project, ...step.$project };
+      continue;
+    } else if (step.$match !== undefined && lastStep.$match !== undefined) {
+      // merge $match steps together
+      lastStep.$match = { ...lastStep.$match, ...step.$match };
+      continue;
+    }
+    lastStep = step;
+    outputSteps.push(lastStep);
+  }
+  return outputSteps;
+}
+
+export const translators = {
+  mongo36: pipeToMongo,
+};

--- a/src/lib/translators/toolchain.ts
+++ b/src/lib/translators/toolchain.ts
@@ -1,0 +1,39 @@
+/**
+ * Translation toolchain utilities.
+ *
+ * The main exported function is `getTranslator` that takes a
+ * backend name as input and returns the corresponding translator.
+ *
+ */
+import { PipelineStep } from '@/lib/steps';
+import { translators as mongoTranslators } from '@/lib/translators/mongo';
+
+type TransformerFunc = (pipeline: Array<PipelineStep>) => any;
+export type TranslatorRegistryType = { [backend: string]: TransformerFunc };
+
+const TRANSLATORS: TranslatorRegistryType = {};
+
+// register mongo translators
+for (const [backend, transformer] of Object.entries(mongoTranslators)) {
+  TRANSLATORS[backend] = transformer;
+}
+
+/** return a function translating an array of pipeline steps to expected backend
+ * steps
+ *
+ * Example usage:
+ * ```typescript
+ * const translator = getTranslator('mongo36');
+ * const result = translator(myPipeline);
+ * ```
+ */
+export function getTranslator(backend: string) {
+  if (TRANSLATORS[backend] === undefined) {
+    throw new Error(
+      `no translator found for backend ${backend}. Available ones are: ${Object.keys(
+        TRANSLATORS,
+      ).join(' | ')}`,
+    );
+  }
+  return TRANSLATORS[backend];
+}

--- a/tests/unit/pipebuild.spec.ts
+++ b/tests/unit/pipebuild.spec.ts
@@ -1,5 +1,7 @@
 import { PipelineStep } from '@/lib/steps';
-import { MongoStep, mongoToPipe, pipeToMongo } from '@/lib/pipeline';
+import { MongoStep } from '@/lib/translators/mongo';
+import { mongoToPipe } from '@/lib/pipeline';
+import { getTranslator } from '@/lib/translators/toolchain';
 
 describe('Pipebuild translator', () => {
   it('generate domain step', () => {
@@ -138,9 +140,11 @@ describe('Pipebuild translator', () => {
 });
 
 describe('Pipeline to mongo translator', () => {
+  const mongo36translator = getTranslator('mongo36');
+
   it('can generate domain steps', () => {
     const pipeline: Array<PipelineStep> = [{ name: 'domain', domain: 'test_cube' }];
-    const querySteps = pipeToMongo(pipeline);
+    const querySteps = mongo36translator(pipeline);
     expect(querySteps).toEqual([{ $match: { domain: 'test_cube' } }]);
   });
 
@@ -156,7 +160,7 @@ describe('Pipeline to mongo translator', () => {
         query: { $concat: ['$country', ' - ', '$Region'] },
       },
     ];
-    const querySteps = pipeToMongo(pipeline);
+    const querySteps = mongo36translator(pipeline);
     expect(querySteps).toEqual([
       { $match: { domain: 'test_cube' } },
       {
@@ -176,7 +180,7 @@ describe('Pipeline to mongo translator', () => {
       { name: 'filter', column: 'Manager', value: 'Pierre' },
       { name: 'filter', column: 'Region', value: 'Europe', operator: 'eq' },
     ];
-    const querySteps = pipeToMongo(pipeline);
+    const querySteps = mongo36translator(pipeline);
     expect(querySteps).toEqual([
       { $match: { domain: 'test_cube', Manager: 'Pierre', Region: 'Europe' } },
     ]);
@@ -195,7 +199,7 @@ describe('Pipeline to mongo translator', () => {
         query: { $group: { _id: '$country', population: { $sum: '$population' } } },
       },
     ];
-    const querySteps = pipeToMongo(pipeline);
+    const querySteps = mongo36translator(pipeline);
     expect(querySteps).toEqual([
       { $match: { domain: 'test_cube', Manager: 'Pierre' } },
       {


### PR DESCRIPTION
Implement a simple translator toolchain to (hypothetically) support multiple backends.

For now, the only backend supported is `mongo3.6`. 

This PR also adds a typesafe `StepMatcher` interface that should help to detect, at compile-time,
step types that are not handled by the translation chain.