### PR TITLE
Feature :: 'replace' step translation in mongo

### DIFF
--- a/doc/steps.md
+++ b/doc/steps.md
@@ -112,3 +112,19 @@ other existing steps.
     query: '$group: {_id: ...}',
 }
 ```
+
+### `replace` step
+
+Replace value in a column, and write resulting column inplace or in a new column.
+
+A replace step has the following strucure:
+
+```javascript
+{
+   name: 'replace',
+   search_column: "column_1",
+   new_column: "column_1", # if empty, inplace by default
+   oldvalue: 'foo',
+   newvalue: 'bar',
+}
+```

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -123,7 +123,7 @@ A replace step has the following strucure:
 {
    name: 'replace',
    search_column: "column_1",
-   new_column: "column_1", # if empty, inplace by default
+   new_column: "column_1", // if empty, inplace by default
    oldvalue: 'foo',
    newvalue: 'bar',
 }

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -58,6 +58,14 @@ export interface CustomStep {
   query: object;
 }
 
+export interface ReplaceStep {
+  name: 'replace';
+  search_column: string;
+  new_column?: string;
+  oldvalue: string;
+  newvalue: string;
+}
+
 export type PipelineStep =
   | DomainStep
   | FilterStep
@@ -66,6 +74,7 @@ export type PipelineStep =
   | DeleteStep
   | NewColumnStep
   | AggregationStep
+  | ReplaceStep
   | CustomStep;
 
 export type PipelineStepName = PipelineStep['name'];

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -33,7 +33,7 @@ export class StepNotSupported extends Error {
  * @param descriptor the method descriptor
  */
 function unsupported(target: BaseTranslator, propertyKey: S.PipelineStepName, descriptor: any) {
-  descriptor.value = function(step: S.PipelineStep) {
+  descriptor.value = function (step: S.PipelineStep) {
     throw new StepNotSupported(step.name);
   };
   descriptor.value.__vqb_step_supported__ = false;
@@ -87,28 +87,31 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
   }
 
   @unsupported
-  filter(step: S.FilterStep) {}
+  filter(step: S.FilterStep) { }
 
   @unsupported
-  domain(step: S.DomainStep) {}
+  domain(step: S.DomainStep) { }
 
   @unsupported
-  select(step: S.SelectStep) {}
+  select(step: S.SelectStep) { }
 
   @unsupported
-  rename(step: S.RenameStep) {}
+  rename(step: S.RenameStep) { }
 
   @unsupported
-  newcolumn(step: S.NewColumnStep) {}
+  newcolumn(step: S.NewColumnStep) { }
 
   @unsupported
-  delete(step: S.DeleteStep) {}
+  delete(step: S.DeleteStep) { }
 
   @unsupported
-  aggregate(step: S.AggregationStep) {}
+  aggregate(step: S.AggregationStep) { }
 
   @unsupported
-  custom(step: S.CustomStep) {}
+  custom(step: S.CustomStep) { }
+
+  @unsupported
+  replace(step: S.ReplaceStep) { }
 
   /**
    * translates an input pipeline into a list of steps that makes sense for the
@@ -144,6 +147,9 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
           break;
         case 'custom':
           result.push(this.custom(step));
+          break;
+        case 'replace':
+          result.push(this.replace(step));
           break;
         default:
           throw new Error(step);

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -33,7 +33,7 @@ export class StepNotSupported extends Error {
  * @param descriptor the method descriptor
  */
 function unsupported(target: BaseTranslator, propertyKey: S.PipelineStepName, descriptor: any) {
-  descriptor.value = function (step: S.PipelineStep) {
+  descriptor.value = function(step: S.PipelineStep) {
     throw new StepNotSupported(step.name);
   };
   descriptor.value.__vqb_step_supported__ = false;
@@ -87,31 +87,31 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
   }
 
   @unsupported
-  filter(step: S.FilterStep) { }
+  filter(step: S.FilterStep) {}
 
   @unsupported
-  domain(step: S.DomainStep) { }
+  domain(step: S.DomainStep) {}
 
   @unsupported
-  select(step: S.SelectStep) { }
+  select(step: S.SelectStep) {}
 
   @unsupported
-  rename(step: S.RenameStep) { }
+  rename(step: S.RenameStep) {}
 
   @unsupported
-  newcolumn(step: S.NewColumnStep) { }
+  newcolumn(step: S.NewColumnStep) {}
 
   @unsupported
-  delete(step: S.DeleteStep) { }
+  delete(step: S.DeleteStep) {}
 
   @unsupported
-  aggregate(step: S.AggregationStep) { }
+  aggregate(step: S.AggregationStep) {}
 
   @unsupported
-  custom(step: S.CustomStep) { }
+  custom(step: S.CustomStep) {}
 
   @unsupported
-  replace(step: S.ReplaceStep) { }
+  replace(step: S.ReplaceStep) {}
 
   /**
    * translates an input pipeline into a list of steps that makes sense for the

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -62,14 +62,14 @@ function transformReplace(step: ReplaceStep): MongoStep {
       [step.new_column || step.search_column]: {
         $cond: [
           {
-            $eq: [`$${step.search_column}`, `${step.oldvalue}`]
+            $eq: [`$${step.search_column}`, `${step.oldvalue}`],
           },
           `${step.newvalue}`,
-          `$${step.search_column}`
-        ]
-      }
-    }
-  }
+          `$${step.search_column}`,
+        ],
+      },
+    },
+  };
 }
 
 const mapper: StepMatcher<MongoStep> = {
@@ -81,7 +81,7 @@ const mapper: StepMatcher<MongoStep> = {
   newcolumn: step => ({ $project: { [step.column]: step.query } }),
   aggregate: transformAggregate,
   custom: step => step.query,
-  replace: transformReplace
+  replace: transformReplace,
 };
 
 export class Mongo36Translator extends BaseTranslator {

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -135,49 +135,57 @@ describe('Pipeline to mongo translator', () => {
   });
 
   it('can generate a basic replace step', () => {
-    const pipeline: Array<PipelineStep> = [{
-      name: 'replace',
-      search_column: "column_1",
-      oldvalue: 'foo',
-      newvalue: 'bar'
-    }];
+    const pipeline: Array<PipelineStep> = [
+      {
+        name: 'replace',
+        search_column: 'column_1',
+        oldvalue: 'foo',
+        newvalue: 'bar',
+      },
+    ];
     const querySteps = mongo36translator.translate(pipeline);
-    expect(querySteps).toEqual([{
-      $addFields: {
-        column_1: {
-          $cond: [
-            {
-              $eq: ["$column_1", "foo"]
-            },
-            "bar",
-            "$column_1"
-          ]
-        }
-      }
-    }]);
+    expect(querySteps).toEqual([
+      {
+        $addFields: {
+          column_1: {
+            $cond: [
+              {
+                $eq: ['$column_1', 'foo'],
+              },
+              'bar',
+              '$column_1',
+            ],
+          },
+        },
+      },
+    ]);
   });
 
   it('can generate a basic replace step in a new column', () => {
-    const pipeline: Array<PipelineStep> = [{
-      name: 'replace',
-      search_column: "column_1",
-      new_column: "column_2",
-      oldvalue: 'foo',
-      newvalue: 'bar'
-    }];
+    const pipeline: Array<PipelineStep> = [
+      {
+        name: 'replace',
+        search_column: 'column_1',
+        new_column: 'column_2',
+        oldvalue: 'foo',
+        newvalue: 'bar',
+      },
+    ];
     const querySteps = mongo36translator.translate(pipeline);
-    expect(querySteps).toEqual([{
-      $addFields: {
-        column_2: {
-          $cond: [
-            {
-              $eq: ["$column_1", "foo"]
-            },
-            "bar",
-            "$column_1"
-          ]
-        }
-      }
-    }]);
+    expect(querySteps).toEqual([
+      {
+        $addFields: {
+          column_2: {
+            $cond: [
+              {
+                $eq: ['$column_1', 'foo'],
+              },
+              'bar',
+              '$column_1',
+            ],
+          },
+        },
+      },
+    ]);
   });
 });

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -133,4 +133,51 @@ describe('Pipeline to mongo translator', () => {
       },
     ]);
   });
+
+  it('can generate a basic replace step', () => {
+    const pipeline: Array<PipelineStep> = [{
+      name: 'replace',
+      search_column: "column_1",
+      oldvalue: 'foo',
+      newvalue: 'bar'
+    }];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([{
+      $addFields: {
+        column_1: {
+          $cond: [
+            {
+              $eq: ["$column_1", "foo"]
+            },
+            "bar",
+            "$column_1"
+          ]
+        }
+      }
+    }]);
+  });
+
+  it('can generate a basic replace step in a new column', () => {
+    const pipeline: Array<PipelineStep> = [{
+      name: 'replace',
+      search_column: "column_1",
+      new_column: "column_2",
+      oldvalue: 'foo',
+      newvalue: 'bar'
+    }];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([{
+      $addFields: {
+        column_2: {
+          $cond: [
+            {
+              $eq: ["$column_1", "foo"]
+            },
+            "bar",
+            "$column_1"
+          ]
+        }
+      }
+    }]);
+  });
 });


### PR DESCRIPTION
Translation of a `replace` step in Mongo aggregation pipeline steps.
The `replace` step aims to replace value in a column, and write the resulting column inplace or in a new column.

Closes [issue #61](https://github.com/ToucanToco/vue-query-builder/issues/61) 