### PR TITLE
Fix :: use $addFields instead of $project in rename and newcolumn steps

### DIFF
--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -59,10 +59,10 @@ const mapper: StepMatcher<MongoStep> = {
   domain: step => ({ $match: { domain: step.domain } }),
   filter: filterstepToMatchstep,
   select: step => ({ $project: fromkeys(step.columns, 1) }),
-  rename: step => ([
+  rename: step => [
     { $addFields: { [step.newname]: `$${step.oldname}` } },
-    { $project: { [step.oldname]: 0 } }
-  ]),
+    { $project: { [step.oldname]: 0 } },
+  ],
   delete: step => ({ $project: fromkeys(step.columns, 0) }),
   newcolumn: step => ({ $addFields: { [step.column]: step.query } }),
   aggregate: transformAggregate,

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -59,9 +59,12 @@ const mapper: StepMatcher<MongoStep> = {
   domain: step => ({ $match: { domain: step.domain } }),
   filter: filterstepToMatchstep,
   select: step => ({ $project: fromkeys(step.columns, 1) }),
-  rename: step => ({ $project: { [step.newname]: `$${step.oldname}` } }),
+  rename: step => ([
+    { $addFields: { [step.newname]: `$${step.oldname}` } },
+    { $project: { [step.oldname]: 0 } }
+  ]),
   delete: step => ({ $project: fromkeys(step.columns, 0) }),
-  newcolumn: step => ({ $project: { [step.column]: step.query } }),
+  newcolumn: step => ({ $addFields: { [step.column]: step.query } }),
   aggregate: transformAggregate,
   custom: step => step.query,
 };

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -62,7 +62,7 @@ describe('Pipeline to mongo translator', () => {
       { $match: { domain: 'test_cube' } },
       {
         $addFields: {
-          zone: '$Region'
+          zone: '$Region',
         },
       },
       {
@@ -157,7 +157,7 @@ describe('Pipeline to mongo translator', () => {
       },
       {
         $addFields: {
-          zone: '$Region'
+          zone: '$Region',
         },
       },
       {


### PR DESCRIPTION
This PR aims to replace $project by $addFields whenever possible.

When projecting a given key in a $project in a Mongo aggregation pipeline, you must specify that you project all other keys if you do not want to lose them. Therefore you would need to manipulate metadata to keep track of available columns, and it would generate a lot of noisy code (imagine that you need to add a new column and to keep 20 other ones, you will have a $project with 21 keys, of which 20 just saying `<key>: 1`...)

$addFields is less verbose, and can be used not only to add a new key but also to modify a key inplace while keeping all other columns. Indeed, specifying an existing field name in an $addFields operation causes the original field to be replaced, while every other columns remain. See [Mongo documentation](https://docs.mongodb.com/manual/reference/operator/aggregation/addFields/)