### PR TITLE
Fix :: simplify mongo pipeline

### DIFF
--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -92,7 +92,7 @@ const mapper: StepMatcher<MongoStep> = {
 export class Mongo36Translator extends BaseTranslator {
   translate(pipeline: Array<PipelineStep>) {
     const mongoSteps = super.translate(pipeline).flat();
-    return simplifyMongoPipeline(mongoSteps);
+    return _simplifyMongoPipeline(mongoSteps);
   }
 }
 Object.assign(Mongo36Translator.prototype, mapper);
@@ -107,7 +107,7 @@ Object.assign(Mongo36Translator.prototype, mapper);
  *
  * @returns the list of simplified mongo steps
  */
-function simplifyMongoPipeline(mongoSteps: Array<MongoStep>): Array<MongoStep> {
+export function _simplifyMongoPipeline(mongoSteps: Array<MongoStep>): Array<MongoStep> {
   const outputSteps: Array<MongoStep> = [];
   let lastStep: MongoStep = mongoSteps[0];
   outputSteps.push(lastStep);

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -24,8 +24,6 @@ function fromkeys(keys: Array<string>, value = 0) {
 function filterstepToMatchstep(step: FilterStep): MongoStep {
   if (step.operator === undefined || step.operator === 'eq') {
     return { $match: { [step.column]: step.value } };
-  } else if (step.operator === 'ne') {
-    return { $match: { [step.column]: { $ne: step.value } } };
   } else {
     throw new Error(`Operator ${step.operator} is not handled yet.`);
   }

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -1,5 +1,6 @@
 import { PipelineStep } from '@/lib/steps';
 import { getTranslator } from '@/lib/translators';
+import { Mongo36Translator, MongoStep, _simplifyMongoPipeline } from '@/lib/translators/mongo';
 
 describe('Mongo translator support tests', () => {
   const mongo36translator = getTranslator('mongo36');

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -294,6 +294,12 @@ describe('Pipeline to mongo translator', () => {
       {
         $group: { _id: '$Zone', Population: { $sum: '$Population' } },
       },
+      {
+        $project: { Zone: '$_id', Population: 1 },
+      },
+      {
+        $project: { Area: '$Zone', Population: 1 },
+      },
     ];
     const querySteps = _simplifyMongoPipeline(mongoPipeline);
     expect(querySteps).toEqual([
@@ -361,6 +367,14 @@ describe('Pipeline to mongo translator', () => {
       },
       {
         $group: { _id: '$Zone', Population: { $sum: '$Population' } },
+      },
+      {
+        $project: { Zone: '$_id', Population: 1 },
+      },
+      // A step with a key referencing as value any key present in the last
+      // step should not be merged with the latter
+      {
+        $project: { Area: '$Zone', Population: 1 },
       },
     ]);
   });


### PR DESCRIPTION
First we made the test case more coherent to give more sense to the query.

Then we managed 2 cases that were not supported:

- We do not want to merge two Mongo steps with common keys

- We do not want to merge two $project steps or two $addFields steps if the second step includes a reference to a key that was declared (created or modified) in the first step.

Closes https://github.com/ToucanToco/vue-query-builder/issues/76