### PR TITLE
Improve :: `filter` step translation to Mongo

### DIFF
--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -22,11 +22,18 @@ function fromkeys(keys: Array<string>, value = 0) {
 }
 
 function filterstepToMatchstep(step: FilterStep): MongoStep {
-  if (step.operator === undefined || step.operator === 'eq') {
-    return { $match: { [step.column]: step.value } };
-  } else {
-    throw new Error(`Operator ${step.operator} is not handled yet.`);
-  }
+  const operatorMapping = {
+    eq: '$eq',
+    ne: '$ne',
+    lt: '$lt',
+    le: '$lte',
+    gt: '$gt',
+    ge: '$gte',
+    in: '$in',
+    nin: '$nin',
+  };
+  step.operator = step.operator || 'eq';
+  return { $match: { [step.column]: { [operatorMapping[step.operator]]: step.value } } };
 }
 
 /** transform an 'aggregate' step into corresponding mongo steps */

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -78,10 +78,30 @@ describe('Pipeline to mongo translator', () => {
       { name: 'domain', domain: 'test_cube' },
       { name: 'filter', column: 'Manager', value: 'Pierre' },
       { name: 'filter', column: 'Region', value: 'Europe', operator: 'eq' },
+      { name: 'filter', column: 'Company', value: 'Toucan', operator: 'ne' },
+      { name: 'filter', column: 'Age', value: 10, operator: 'lt' },
+      { name: 'filter', column: 'Height', value: 175, operator: 'le' },
+      { name: 'filter', column: 'Weight', value: 60, operator: 'gt' },
+      { name: 'filter', column: 'Value', value: 100, operator: 'ge' },
+      { name: 'filter', column: 'Category', value: ['Foo', 'Bar'], operator: 'in' },
+      { name: 'filter', column: 'Code', value: [0, 42], operator: 'nin' },
     ];
     const querySteps = mongo36translator.translate(pipeline);
     expect(querySteps).toEqual([
-      { $match: { domain: 'test_cube', Manager: 'Pierre', Region: 'Europe' } },
+      {
+        $match: {
+          domain: 'test_cube',
+          Manager: { $eq: 'Pierre' },
+          Region: { $eq: 'Europe' },
+          Company: { $ne: 'Toucan' },
+          Age: { $lt: 10 },
+          Height: { $lte: 175 },
+          Weight: { $gt: 60 },
+          Value: { $gte: 100 },
+          Category: { $in: ['Foo', 'Bar'] },
+          Code: { $nin: [0, 42] },
+        },
+      },
     ]);
   });
 
@@ -148,7 +168,7 @@ describe('Pipeline to mongo translator', () => {
     ];
     const querySteps = mongo36translator.translate(pipeline);
     expect(querySteps).toEqual([
-      { $match: { domain: 'test_cube', Manager: 'Pierre' } },
+      { $match: { domain: 'test_cube', Manager: { $eq: 'Pierre' } } },
       {
         $project: {
           Manager: 0,


### PR DESCRIPTION
Complete filter step implementation to support every basic operator among:

- 'eq' (equal to)
- 'ne' (not equal to)
- 'gt' (greater than)
- 'gte' (greater than or equal)
- 'lt' (less than)
- 'lte' (less than or equal)
- 'in' (in
- 'nin' (not in)

Related to issue https://github.com/ToucanToco/vue-query-builder/issues/63
But does not support complex filtering with (potentially nested) logical conditions