### PR TITLE
Improve :: `aggregate` step mongo

### DIFF
--- a/doc/steps.md
+++ b/doc/steps.md
@@ -92,8 +92,8 @@ An aggreation step has the following strucure:
    on: ['column1', 'column2'],
    aggregations:  [
       {
-          name: 'sum_value1'
-          operation: 'sum'
+          newcolumn: 'sum_value1'
+          aggfunction: 'sum'
           column: 'value1',
       }
     // ...

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -40,7 +40,7 @@ interface AggFunctionStep {
   /** name of the agg function step, (typically the name of the output column) */
   name: string;
   /** the aggregation operation (e.g. `sum` or `count`) */
-  aggfunction: string;
+  aggfunction?: 'sum' | 'avg' | 'count' | 'min' | 'max';
   /** the column the aggregation function is working on */
   column: string;
 }

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -37,10 +37,10 @@ export interface NewColumnStep {
 }
 
 interface AggFunctionStep {
-  /** name of the agg function step, (typically the name of the output column) */
-  name: string;
+  /** Name of the output column */
+  newcolumn: string;
   /** the aggregation operation (e.g. `sum` or `count`) */
-  aggfunction?: 'sum' | 'avg' | 'count' | 'min' | 'max';
+  aggfunction: 'sum' | 'avg' | 'count' | 'min' | 'max';
   /** the column the aggregation function is working on */
   column: string;
 }

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -42,11 +42,11 @@ function transformAggregate(step: AggregationStep): Array<MongoStep> {
     if (aggf_step.aggfunction === 'count') {
       // There is no `$count` operator in Mongo, we have to `$sum` 1s to get
       // an equivalent result
-      group[aggf_step.name] = {
+      group[aggf_step.newcolumn] = {
         $sum: 1,
       };
     } else {
-      group[aggf_step.name] = {
+      group[aggf_step.newcolumn] = {
         [`$${aggf_step.aggfunction}`]: `$${aggf_step.column}`,
       };
     }

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -39,9 +39,17 @@ function transformAggregate(step: AggregationStep): Array<MongoStep> {
     idblock[colname] = `$${colname}`;
   }
   for (const aggf_step of step.aggregations) {
-    group[aggf_step.name] = {
-      [`$${aggf_step.aggfunction}`]: `$${aggf_step.column}`,
-    };
+    if (aggf_step.aggfunction === 'count') {
+      // There is no `$count` operator in Mongo, we have to `$sum` 1s to get
+      // an equivalent result
+      group[aggf_step.name] = {
+        $sum: 1,
+      };
+    } else {
+      group[aggf_step.name] = {
+        [`$${aggf_step.aggfunction}`]: `$${aggf_step.column}`,
+      };
+    }
   }
   for (const group_key of Object.keys(group)) {
     if (group_key === '_id') {

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -107,6 +107,16 @@ describe('Pipeline to mongo translator', () => {
             aggfunction: 'min',
             column: 'col1',
           },
+          {
+            name: 'maximum',
+            aggfunction: 'max',
+            column: 'col3',
+          },
+          {
+            name: 'number_rows',
+            aggfunction: 'count',
+            column: 'col3',
+          },
         ],
       },
     ];
@@ -119,6 +129,8 @@ describe('Pipeline to mongo translator', () => {
           sum: { $sum: '$col1' },
           average: { $avg: '$col2' },
           minimum: { $min: '$col1' },
+          maximum: { $max: '$col3' },
+          number_rows: { $sum: 1 },
         },
       },
       {
@@ -128,6 +140,8 @@ describe('Pipeline to mongo translator', () => {
           sum: 1,
           average: 1,
           minimum: 1,
+          maximum: 1,
+          number_rows: 1,
         },
       },
     ]);

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -93,27 +93,27 @@ describe('Pipeline to mongo translator', () => {
         on: ['col_agg1', 'col_agg2'],
         aggregations: [
           {
-            name: 'sum',
+            newcolumn: 'sum',
             aggfunction: 'sum',
             column: 'col1',
           },
           {
-            name: 'average',
+            newcolumn: 'average',
             aggfunction: 'avg',
             column: 'col2',
           },
           {
-            name: 'minimum',
+            newcolumn: 'minimum',
             aggfunction: 'min',
             column: 'col1',
           },
           {
-            name: 'maximum',
+            newcolumn: 'maximum',
             aggfunction: 'max',
             column: 'col3',
           },
           {
-            name: 'number_rows',
+            newcolumn: 'number_rows',
             aggfunction: 'count',
             column: 'col3',
           },


### PR DESCRIPTION
Restrict AggFunctionStep interface to only support basic aggregation functions and improve transformAggregate to support every basic aggregation function among:

- sum
- avg
- count
- min
- max

Related to issue https://github.com/ToucanToco/vue-query-builder/issues/30
But dos not support more complex aggregations such as count_distinct