### PR TITLE
Feature :: `sort` step mongo

### DIFF
--- a/doc/steps.md
+++ b/doc/steps.md
@@ -132,7 +132,7 @@ A replace step has the following strucure:
 ### 'sort' step
 
 Sort values in one or several columns. Order can be either 'asc' or 'desc'.
-When sorting on several columns, order of columns specified in `columns`matters,
+When sorting on several columns, order of columns specified in `columns` matters,
 and the `order` parameter must be of same length as `columns`. By default, if
 `order` is not specified, it is considered as 'asc'.
 

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -139,7 +139,7 @@ and the `order` parameter must be of same length as `columns`. By default, if
 ```javascript
 {
     name: 'sort',
-    columns: ['foo', 'bar']
+    columns: ['foo', 'bar'],
     order: ['asc', 'desc']
 }
 ```

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -128,3 +128,18 @@ A replace step has the following strucure:
    newvalue: 'bar',
 }
 ```
+
+### 'sort' step
+
+Sort values in one or several columns. Order can be either 'asc' or 'desc'.
+When sorting on several columns, order of columns specified in `columns`matters,
+and the `order` parameter must be of same length as `columns`. By default, if
+`order` is not specified, it is considered as 'asc'.
+
+```javascript
+{
+    name: 'sort',
+    columns: ['foo', 'bar']
+    order: ['asc', 'desc']
+}
+```

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -66,6 +66,12 @@ export interface ReplaceStep {
   newvalue: string;
 }
 
+export interface SortStep {
+  name: 'sort';
+  columns: Array<string>;
+  order?: Array<'asc' | 'desc'>;
+}
+
 export type PipelineStep =
   | DomainStep
   | FilterStep
@@ -75,6 +81,7 @@ export type PipelineStep =
   | NewColumnStep
   | AggregationStep
   | ReplaceStep
+  | SortStep
   | CustomStep;
 
 export type PipelineStepName = PipelineStep['name'];

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -113,6 +113,9 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
   @unsupported
   replace(step: S.ReplaceStep) {}
 
+  @unsupported
+  sort(step: S.SortStep) {}
+
   /**
    * translates an input pipeline into a list of steps that makes sense for the
    * targeted backend.
@@ -150,6 +153,9 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
           break;
         case 'replace':
           result.push(this.replace(step));
+          break;
+        case 'sort':
+          result.push(this.sort(step));
           break;
         default:
           throw new Error(step);

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -89,12 +89,10 @@ function transformReplace(step: ReplaceStep): MongoStep {
 
 /** transform a 'sort' step into corresponding mongo steps */
 function transformSort(step: SortStep): MongoStep {
-  let sortMongo: PropMap<number> = {};
-  if (step.order === undefined) {
-    step.order = Array(step.columns.length).fill('asc');
-  }
+  const sortMongo: PropMap<number> = {};
+  const sortOrders = step.order === undefined ? Array(step.columns.length).fill('asc') : step.order;
   for (let i = 0; i < step.columns.length; i++) {
-    const order = step.order[i] === 'asc' ? 1 : -1;
+    const order = sortOrders[i] === 'asc' ? 1 : -1;
     sortMongo[step.columns[i]] = order;
   }
   return { $sort: sortMongo };

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -467,4 +467,89 @@ describe('Pipeline to mongo translator', () => {
       },
     ]);
   });
+
+  it('can generate a basic sort step on one column', () => {
+    const pipeline: Array<PipelineStep> = [
+      {
+        name: 'sort',
+        columns: ['foo'],
+        order: ['desc'],
+      },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    Mongo36Translator;
+    expect(querySteps).toEqual([
+      {
+        $sort: {
+          foo: -1,
+        },
+      },
+    ]);
+  });
+
+  it('can generate a sort step on multiple columns', () => {
+    const pipeline: Array<PipelineStep> = [
+      {
+        name: 'sort',
+        columns: ['foo', 'bar'],
+        order: ['asc', 'desc'],
+      },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    Mongo36Translator;
+    expect(querySteps).toEqual([
+      {
+        $sort: {
+          foo: 1,
+          bar: -1,
+        },
+      },
+    ]);
+  });
+
+  it('can generate a sort step on multiple columns with default order', () => {
+    const pipeline: Array<PipelineStep> = [
+      {
+        name: 'sort',
+        columns: ['foo', 'bar'],
+      },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    Mongo36Translator;
+    expect(querySteps).toEqual([
+      {
+        $sort: {
+          foo: 1,
+          bar: 1,
+        },
+      },
+    ]);
+  });
+
+  // it('can generate a basic sort step on one column', () => {
+  //   const pipeline: Array<PipelineStep> = [
+  //     {
+  //       name: 'sort',
+  //       columns: ['foo', 'bar'],
+  //       order: ['asc', 'desc'],
+  //     },
+  //   ];
+  //   const querySteps = mongo36translator.translate(pipeline);
+  //   Mongo36Translator;
+  //   expect(querySteps).toEqual([
+  //     {
+  //       $addFields: {
+  //         column_2: {
+  //           $cond: [
+  //             {
+  //               $eq: ['$column_1', 'foo'],
+  //             },
+  //             'bar',
+  //             '$column_1',
+  //           ],
+  //         },
+  //       },
+  //     },
+  //   ]);
+  // });
 });

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -477,7 +477,6 @@ describe('Pipeline to mongo translator', () => {
       },
     ];
     const querySteps = mongo36translator.translate(pipeline);
-    Mongo36Translator;
     expect(querySteps).toEqual([
       {
         $sort: {
@@ -496,7 +495,6 @@ describe('Pipeline to mongo translator', () => {
       },
     ];
     const querySteps = mongo36translator.translate(pipeline);
-    Mongo36Translator;
     expect(querySteps).toEqual([
       {
         $sort: {
@@ -515,7 +513,6 @@ describe('Pipeline to mongo translator', () => {
       },
     ];
     const querySteps = mongo36translator.translate(pipeline);
-    Mongo36Translator;
     expect(querySteps).toEqual([
       {
         $sort: {
@@ -525,31 +522,4 @@ describe('Pipeline to mongo translator', () => {
       },
     ]);
   });
-
-  // it('can generate a basic sort step on one column', () => {
-  //   const pipeline: Array<PipelineStep> = [
-  //     {
-  //       name: 'sort',
-  //       columns: ['foo', 'bar'],
-  //       order: ['asc', 'desc'],
-  //     },
-  //   ];
-  //   const querySteps = mongo36translator.translate(pipeline);
-  //   Mongo36Translator;
-  //   expect(querySteps).toEqual([
-  //     {
-  //       $addFields: {
-  //         column_2: {
-  //           $cond: [
-  //             {
-  //               $eq: ['$column_1', 'foo'],
-  //             },
-  //             'bar',
-  //             '$column_1',
-  //           ],
-  //         },
-  //       },
-  //     },
-  //   ]);
-  // });
 });

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -1,6 +1,6 @@
 import { PipelineStep } from '@/lib/steps';
 import { getTranslator } from '@/lib/translators';
-import { Mongo36Translator, MongoStep, _simplifyMongoPipeline } from '@/lib/translators/mongo';
+import { MongoStep, _simplifyMongoPipeline } from '@/lib/translators/mongo';
 
 describe('Mongo translator support tests', () => {
   const mongo36translator = getTranslator('mongo36');


### PR DESCRIPTION
Support translation of a `sort` step in Mongo Aggregation Pipeline. Sort can be expressed on one or several columns; for any column, sorting order can be either "asc" or "desc".

Closes https://github.com/ToucanToco/vue-query-builder/issues/70