### PR TITLE
Feature :: Top step translation to mongo

### DIFF
--- a/doc/steps.md
+++ b/doc/steps.md
@@ -155,3 +155,17 @@ Replace null values by a given value in a column.
     value: "bar"
 }
 ```
+
+### 'top' step
+
+Return top N rows by group if `groups` is specified, else over full dataset
+
+```javascript
+{
+  name: 'top',
+  groups: ['foo']
+  value: 'bar',
+  sort: 'desc' // or 'asc'
+  limit: 10
+}
+```

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -164,7 +164,7 @@ Return top N rows by group if `groups` is specified, else over full dataset.
 {
   name: 'top',
   groups: ['foo'],
-  value: 'bar',
+  rank_on: 'bar',
   sort: 'desc', // or 'asc'
   limit: 10
 }

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -83,7 +83,7 @@ export interface FillnaStep {
 export interface TopStep {
   name: 'top';
   groups?: Array<string>;
-  value: string;
+  rank_on: string;
   sort: 'asc' | 'desc';
   limit: number;
 }

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -80,6 +80,14 @@ export interface FillnaStep {
   value: PrimitiveType;
 }
 
+export interface TopStep {
+  name: 'top';
+  groups?: Array<string>;
+  value: string;
+  sort: 'asc' | 'desc';
+  limit: number;
+}
+
 export type PipelineStep =
   | DomainStep
   | FilterStep
@@ -91,6 +99,7 @@ export type PipelineStep =
   | ReplaceStep
   | SortStep
   | FillnaStep
+  | TopStep
   | CustomStep;
 
 export type PipelineStepName = PipelineStep['name'];

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -119,6 +119,9 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
   @unsupported
   fillna(step: S.FillnaStep) {}
 
+  @unsupported
+  top(step: S.TopStep) {}
+
   /**
    * translates an input pipeline into a list of steps that makes sense for the
    * targeted backend.
@@ -162,6 +165,9 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
           break;
         case 'fillna':
           result.push(this.fillna(step));
+          break;
+        case 'top':
+          result.push(this.top(step));
           break;
         default:
           throw new Error(step);

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -108,7 +108,6 @@ function transformSort(step: SortStep): MongoStep {
 /** transform an 'top' step into corresponding mongo steps */
 function transformTop(step: TopStep): Array<MongoStep> {
   const sortOrder = step.sort === 'asc' ? 1 : -1;
-  const groupMongo: MongoStep = {};
   let groupCols: PropMap<string> | null = {};
 
   // Prepare the $group Mongo step
@@ -119,14 +118,10 @@ function transformTop(step: TopStep): Array<MongoStep> {
   } else {
     groupCols = null;
   }
-  groupMongo['$group'] = {
-    _id: groupCols,
-    _tcAppArray: { $push: '$$ROOT' },
-  };
 
   return [
     { $sort: { [step.value]: sortOrder } },
-    groupMongo,
+    { $group: { _id: groupCols, _tcAppArray: { $push: '$$ROOT' } } },
     { $project: { _tcAppTopElems: { $slice: ['$_tcAppArray', step.limit] } } },
     { $unwind: '$_tcAppTopElems' },
     { $replaceRoot: { newRoot: '$_tcAppTopElems' } },

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -1,6 +1,13 @@
 /** This module contains mongo specific translation operations */
 
-import { AggregationStep, FilterStep, PipelineStep, ReplaceStep, SortStep } from '@/lib/steps';
+import {
+  AggregationStep,
+  FilterStep,
+  PipelineStep,
+  ReplaceStep,
+  SortStep,
+  TopStep,
+} from '@/lib/steps';
 import { StepMatcher } from '@/lib/matcher';
 import { BaseTranslator } from '@/lib/translators/base';
 
@@ -98,6 +105,34 @@ function transformSort(step: SortStep): MongoStep {
   return { $sort: sortMongo };
 }
 
+/** transform an 'top' step into corresponding mongo steps */
+function transformTop(step: TopStep): Array<MongoStep> {
+  const sortOrder = step.sort === 'asc' ? 1 : -1;
+  const groupMongo: MongoStep = {};
+  let groupCols: PropMap<string> | null = {};
+
+  // Prepare the $group Mongo step
+  if (step.groups) {
+    for (const col of step.groups) {
+      groupCols[col] = `$${col}`;
+    }
+  } else {
+    groupCols = null;
+  }
+  groupMongo['$group'] = {
+    _id: groupCols,
+    _tcAppArray: { $push: '$$ROOT' },
+  };
+
+  return [
+    { $sort: { [step.value]: sortOrder } },
+    groupMongo,
+    { $project: { _tcAppTopElems: { $slice: ['$_tcAppArray', step.limit] } } },
+    { $unwind: '$_tcAppTopElems' },
+    { $replaceRoot: { newRoot: '$_tcAppTopElems' } },
+  ];
+}
+
 const mapper: StepMatcher<MongoStep> = {
   domain: step => ({ $match: { domain: step.domain } }),
   filter: filterstepToMatchstep,
@@ -119,7 +154,7 @@ const mapper: StepMatcher<MongoStep> = {
       },
     },
   }),
-  top: step => ({}),
+  top: transformTop,
 };
 
 export class Mongo36Translator extends BaseTranslator {

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -119,6 +119,7 @@ const mapper: StepMatcher<MongoStep> = {
       },
     },
   }),
+  top: step => ({}),
 };
 
 export class Mongo36Translator extends BaseTranslator {

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -120,7 +120,7 @@ function transformTop(step: TopStep): Array<MongoStep> {
   }
 
   return [
-    { $sort: { [step.value]: sortOrder } },
+    { $sort: { [step.rank_on]: sortOrder } },
     { $group: { _id: groupCols, _tcAppArray: { $push: '$$ROOT' } } },
     { $project: { _tcAppTopElems: { $slice: ['$_tcAppArray', step.limit] } } },
     { $unwind: '$_tcAppTopElems' },

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -577,4 +577,28 @@ describe('Pipeline to mongo translator', () => {
       { $replaceRoot: { newRoot: '$_tcAppTopElems' } },
     ]);
   });
+
+  it('can generate a top step without groups', () => {
+    const pipeline: Array<PipelineStep> = [
+      {
+        name: 'top',
+        value: 'bar',
+        sort: 'asc',
+        limit: 3,
+      },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      { $sort: { bar: 1 } },
+      {
+        $group: {
+          _id: null,
+          _tcAppArray: { $push: '$$ROOT' },
+        },
+      },
+      { $project: { _tcAppTopElems: { $slice: ['$_tcAppArray', 3] } } },
+      { $unwind: '$_tcAppTopElems' },
+      { $replaceRoot: { newRoot: '$_tcAppTopElems' } },
+    ]);
+  });
 });

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -537,20 +537,6 @@ describe('Pipeline to mongo translator', () => {
     ]);
   });
 
-  it('can generate a fillna step', () => {
-    const pipeline: Array<PipelineStep> = [
-      {
-        name: 'fillna',
-        column: 'foo',
-        value: 'bar',
-      },
-    ];
-    const querySteps = mongo36translator.translate(pipeline);
-    expect(querySteps).toEqual([
-      { $addFields: { foo: { $cond: [{ $eq: ['$foo', null] }, 'bar', '$foo'] } } },
-    ]);
-  });
-
   it('can generate a top step with groups', () => {
     const pipeline: Array<PipelineStep> = [
       {

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -542,7 +542,7 @@ describe('Pipeline to mongo translator', () => {
       {
         name: 'top',
         groups: ['foo'],
-        value: 'bar',
+        rank_on: 'bar',
         sort: 'desc',
         limit: 10,
       },
@@ -568,7 +568,7 @@ describe('Pipeline to mongo translator', () => {
     const pipeline: Array<PipelineStep> = [
       {
         name: 'top',
-        value: 'bar',
+        rank_on: 'bar',
         sort: 'asc',
         limit: 3,
       },


### PR DESCRIPTION
Return top N rows, by group if `groups` is specified, else over full dataset.

```javascript
{
  name: 'top',
  groups: ['foo']
  value: 'bar',
  sort: 'desc' // or 'asc'
  limit: 10
}
```

Closes https://github.com/ToucanToco/vue-query-builder/issues/66