### PR TITLE
feature :: readonly steps

### DIFF
--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -4,81 +4,81 @@
 
 type PrimitiveType = number | boolean | string | Date;
 
-export interface DomainStep {
+export type DomainStep = Readonly<{
   name: 'domain';
   domain: string;
-}
+}>;
 
-export interface FilterStep {
+export type FilterStep = Readonly<{
   name: 'filter';
   column: string;
   value: any;
   operator?: 'eq' | 'ne' | 'gt' | 'ge' | 'lt' | 'le' | 'in' | 'nin';
-}
+}>;
 
-export interface SelectStep {
+export type SelectStep = Readonly<{
   name: 'select';
   columns: Array<string>;
-}
+}>;
 
-export interface RenameStep {
+export type RenameStep = Readonly<{
   name: 'rename';
   oldname: string;
   newname: string;
-}
+}>;
 
-export interface DeleteStep {
+export type DeleteStep = Readonly<{
   name: 'delete';
   columns: Array<string>;
-}
+}>;
 
-export interface NewColumnStep {
+export type NewColumnStep = Readonly<{
   name: 'newcolumn';
   column: string;
   query: object | string;
-}
+}>;
 
-interface AggFunctionStep {
+type AggFunctionStep = Readonly<{
   /** Name of the output column */
   newcolumn: string;
   /** the aggregation operation (e.g. `sum` or `count`) */
   aggfunction: 'sum' | 'avg' | 'count' | 'min' | 'max';
   /** the column the aggregation function is working on */
   column: string;
-}
+}>;
 
-export interface AggregationStep {
+export type AggregationStep = Readonly<{
   name: 'aggregate';
   /** the list columns we want to aggregate on */
   on: Array<string>;
   /** the list of aggregation operations to perform */
   aggregations: Array<AggFunctionStep>;
-}
+}>;
 
-export interface CustomStep {
+export type CustomStep = Readonly<{
   name: 'custom';
   query: object;
-}
+}>;
 
-export interface ReplaceStep {
+export type ReplaceStep = Readonly<{
   name: 'replace';
   search_column: string;
   new_column?: string;
   oldvalue: string;
   newvalue: string;
-}
+}>;
 
-export interface SortStep {
+export type SortStep = Readonly<{
   name: 'sort';
   columns: Array<string>;
   order?: Array<'asc' | 'desc'>;
-}
+}>;
 
-export interface FillnaStep {
+export type FillnaStep = Readonly<{
   name: 'fillna';
   column: string;
   value: PrimitiveType;
-}
+}>;
 
 export type PipelineStep =
   | DomainStep

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -128,7 +128,8 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
    */
   translate(pipeline: Array<S.PipelineStep>): Array<OutputStep> {
     const result: Array<OutputStep> = [];
-    for (const step of pipeline) {
+    for (let step of pipeline) {
+      step = Object.freeze(step);
       switch (step.name) {
         case 'domain':
           result.push(this.domain(step));

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -32,8 +32,8 @@ function filterstepToMatchstep(step: FilterStep): MongoStep {
     in: '$in',
     nin: '$nin',
   };
-  step.operator = step.operator || 'eq';
-  return { $match: { [step.column]: { [operatorMapping[step.operator]]: step.value } } };
+  const operator = step.operator || 'eq';
+  return { $match: { [step.column]: { [operatorMapping[operator]]: step.value } } };
 }
 
 /** transform an 'aggregate' step into corresponding mongo steps */


### PR DESCRIPTION
make step types readonly both at compile time and run time.

This will avoid side-effects during transformation callbacks.

Closes #100
