### PR TITLE
conventions :: adopt coding conventions

### DIFF
--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -4,40 +4,6 @@
 
 type PrimitiveType = number | boolean | string | Date;
 
-export type DomainStep = Readonly<{
-  name: 'domain';
-  domain: string;
-}>;
-
-export type FilterStep = Readonly<{
-  name: 'filter';
-  column: string;
-  value: any;
-  operator?: 'eq' | 'ne' | 'gt' | 'ge' | 'lt' | 'le' | 'in' | 'nin';
-}>;
-
-export type SelectStep = Readonly<{
-  name: 'select';
-  columns: Array<string>;
-}>;
-
-export type RenameStep = Readonly<{
-  name: 'rename';
-  oldname: string;
-  newname: string;
-}>;
-
-export type DeleteStep = Readonly<{
-  name: 'delete';
-  columns: Array<string>;
-}>;
-
-export type NewColumnStep = Readonly<{
-  name: 'newcolumn';
-  column: string;
-  query: object | string;
-}>;
-
 type AggFunctionStep = Readonly<{
   /** Name of the output column */
   newcolumn: string;
@@ -60,6 +26,48 @@ export type CustomStep = Readonly<{
   query: object;
 }>;
 
+export type DeleteStep = Readonly<{
+  name: 'delete';
+  columns: Array<string>;
+}>;
+
+export type DomainStep = Readonly<{
+  name: 'domain';
+  domain: string;
+}>;
+
+export type FillnaStep = Readonly<{
+  name: 'fillna';
+  column: string;
+  value: PrimitiveType;
+}>;
+
+export type FilterStep = Readonly<{
+  name: 'filter';
+  column: string;
+  value: any;
+  operator?: 'eq' | 'ne' | 'gt' | 'ge' | 'lt' | 'le' | 'in' | 'nin';
+}>;
+
+export type NewColumnStep = Readonly<{
+  name: 'newcolumn';
+  column: string;
+  query: object | string;
+}>;
+
+export interface PercentageStep {
+  name: 'percentage';
+  new_column?: string;
+  column: string;
+  group?: Array<string>;
+}
+
+export type RenameStep = Readonly<{
+  name: 'rename';
+  oldname: string;
+  newname: string;
+}>;
+
 export type ReplaceStep = Readonly<{
   name: 'replace';
   search_column: string;
@@ -68,16 +76,15 @@ export type ReplaceStep = Readonly<{
   newvalue: string;
 }>;
 
+export type SelectStep = Readonly<{
+  name: 'select';
+  columns: Array<string>;
+}>;
+
 export type SortStep = Readonly<{
   name: 'sort';
   columns: Array<string>;
   order?: Array<'asc' | 'desc'>;
-}>;
-
-export type FillnaStep = Readonly<{
-  name: 'fillna';
-  column: string;
-  value: PrimitiveType;
 }>;
 
 export interface TopStep {
@@ -88,26 +95,19 @@ export interface TopStep {
   limit: number;
 }
 
-export interface PercentageStep {
-  name: 'percentage';
-  new_column?: string;
-  column: string;
-  group?: Array<string>;
-}
-
 export type PipelineStep =
-  | DomainStep
-  | FilterStep
-  | SelectStep
-  | RenameStep
-  | DeleteStep
-  | NewColumnStep
   | AggregationStep
-  | ReplaceStep
-  | SortStep
+  | CustomStep
+  | DeleteStep
+  | DomainStep
   | FillnaStep
-  | TopStep
+  | FilterStep
+  | NewColumnStep
   | PercentageStep
-  | CustomStep;
+  | RenameStep
+  | ReplaceStep
+  | SelectStep
+  | SortStep
+  | TopStep;
 
 export type PipelineStepName = PipelineStep['name'];

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -55,12 +55,12 @@ export type NewColumnStep = Readonly<{
   query: object | string;
 }>;
 
-export interface PercentageStep {
+export type PercentageStep = Readonly<{
   name: 'percentage';
   new_column?: string;
   column: string;
   group?: Array<string>;
-}
+}>;
 
 export type RenameStep = Readonly<{
   name: 'rename';
@@ -87,13 +87,13 @@ export type SortStep = Readonly<{
   order?: Array<'asc' | 'desc'>;
 }>;
 
-export interface TopStep {
+export type TopStep = Readonly<{
   name: 'top';
   groups?: Array<string>;
   rank_on: string;
   sort: 'asc' | 'desc';
   limit: number;
-}
+}>;
 
 export type PipelineStep =
   | AggregationStep

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -87,43 +87,43 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
   }
 
   @unsupported
-  filter(step: S.FilterStep) {}
-
-  @unsupported
-  domain(step: S.DomainStep) {}
-
-  @unsupported
-  select(step: S.SelectStep) {}
-
-  @unsupported
-  rename(step: S.RenameStep) {}
-
-  @unsupported
-  newcolumn(step: S.NewColumnStep) {}
-
-  @unsupported
-  delete(step: S.DeleteStep) {}
-
-  @unsupported
   aggregate(step: S.AggregationStep) {}
 
   @unsupported
   custom(step: S.CustomStep) {}
 
   @unsupported
-  replace(step: S.ReplaceStep) {}
+  domain(step: S.DomainStep) {}
 
   @unsupported
-  sort(step: S.SortStep) {}
+  delete(step: S.DeleteStep) {}
 
   @unsupported
   fillna(step: S.FillnaStep) {}
 
   @unsupported
-  top(step: S.TopStep) {}
+  filter(step: S.FilterStep) {}
+
+  @unsupported
+  newcolumn(step: S.NewColumnStep) {}
 
   @unsupported
   percentage(step: S.PercentageStep) {}
+
+  @unsupported
+  rename(step: S.RenameStep) {}
+
+  @unsupported
+  replace(step: S.ReplaceStep) {}
+
+  @unsupported
+  select(step: S.SelectStep) {}
+
+  @unsupported
+  sort(step: S.SortStep) {}
+
+  @unsupported
+  top(step: S.TopStep) {}
 
   /**
    * translates an input pipeline into a list of steps that makes sense for the

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -95,29 +95,29 @@ function transformPercentage(step: PercentageStep): Array<MongoStep> {
   }
   groupMongo['$group'] = {
     _id: groupCols,
-    _tcAppArray: { $push: '$$ROOT' },
-    _tcTotalDenum: { $sum: `$${step.column}` },
+    _vqbAppArray: { $push: '$$ROOT' },
+    _vqbTotalDenum: { $sum: `$${step.column}` },
   };
 
   // Prepare the $project Mongo step
   projectMongo['$project'] = {
     [newCol]: {
       $cond: [
-        { $eq: ['$_tcTotalDenum', 0] },
+        { $eq: ['$_vqbTotalDenum', 0] },
         null,
-        { $divide: [`$_tcAppArray.${step.column}`, '$_tcTotalDenum'] },
+        { $divide: [`$_vqbAppArray.${step.column}`, '$_vqbTotalDenum'] },
       ],
     },
-    _tcTotalDenum: 0, // We do not want to keep that column at the end
+    _vqbTotalDenum: 0, // We do not want to keep that column at the end
   };
 
   return [
     groupMongo,
-    { $unwind: '$_tcAppArray' },
+    { $unwind: '$_vqbAppArray' },
     projectMongo,
-    // Line below: Keep all columns that were not used in computation, 'stored' in _tcAppArray
-    { $replaceRoot: { newRoot: { $mergeObjects: ['$_tcAppArray', '$$ROOT'] } } },
-    { $project: { _tcAppArray: 0 } }, // We do not want to keep that column at the end
+    // Line below: Keep all columns that were not used in computation, 'stored' in _vqbAppArray
+    { $replaceRoot: { newRoot: { $mergeObjects: ['$_vqbAppArray', '$$ROOT'] } } },
+    { $project: { _vqbAppArray: 0 } }, // We do not want to keep that column at the end
   ];
 }
 
@@ -165,10 +165,10 @@ function transformTop(step: TopStep): Array<MongoStep> {
 
   return [
     { $sort: { [step.rank_on]: sortOrder } },
-    { $group: { _id: groupCols, _tcAppArray: { $push: '$$ROOT' } } },
-    { $project: { _tcAppTopElems: { $slice: ['$_tcAppArray', step.limit] } } },
-    { $unwind: '$_tcAppTopElems' },
-    { $replaceRoot: { newRoot: '$_tcAppTopElems' } },
+    { $group: { _id: groupCols, _vqbAppArray: { $push: '$$ROOT' } } },
+    { $project: { _vqbAppTopElems: { $slice: ['$_vqbAppArray', step.limit] } } },
+    { $unwind: '$_vqbAppTopElems' },
+    { $replaceRoot: { newRoot: '$_vqbAppTopElems' } },
   ];
 }
 

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -555,12 +555,12 @@ describe('Pipeline to mongo translator', () => {
           _id: {
             foo: '$foo',
           },
-          _tcAppArray: { $push: '$$ROOT' },
+          _vqbAppArray: { $push: '$$ROOT' },
         },
       },
-      { $project: { _tcAppTopElems: { $slice: ['$_tcAppArray', 10] } } },
-      { $unwind: '$_tcAppTopElems' },
-      { $replaceRoot: { newRoot: '$_tcAppTopElems' } },
+      { $project: { _vqbAppTopElems: { $slice: ['$_vqbAppArray', 10] } } },
+      { $unwind: '$_vqbAppTopElems' },
+      { $replaceRoot: { newRoot: '$_vqbAppTopElems' } },
     ]);
   });
 
@@ -579,12 +579,12 @@ describe('Pipeline to mongo translator', () => {
       {
         $group: {
           _id: null,
-          _tcAppArray: { $push: '$$ROOT' },
+          _vqbAppArray: { $push: '$$ROOT' },
         },
       },
-      { $project: { _tcAppTopElems: { $slice: ['$_tcAppArray', 3] } } },
-      { $unwind: '$_tcAppTopElems' },
-      { $replaceRoot: { newRoot: '$_tcAppTopElems' } },
+      { $project: { _vqbAppTopElems: { $slice: ['$_vqbAppArray', 3] } } },
+      { $unwind: '$_vqbAppTopElems' },
+      { $replaceRoot: { newRoot: '$_vqbAppTopElems' } },
     ]);
   });
 
@@ -602,26 +602,26 @@ describe('Pipeline to mongo translator', () => {
       {
         $group: {
           _id: { foo: '$foo' },
-          _tcAppArray: { $push: '$$ROOT' },
-          _tcTotalDenum: { $sum: '$bar' },
+          _vqbAppArray: { $push: '$$ROOT' },
+          _vqbTotalDenum: { $sum: '$bar' },
         },
       },
-      { $unwind: '$_tcAppArray' },
+      { $unwind: '$_vqbAppArray' },
       {
         $project: {
           new_col: {
             // we need to explicitely manage the case where '$total_denum' is null otherwise the query may just fail
             $cond: [
-              { $eq: ['$_tcTotalDenum', 0] },
+              { $eq: ['$_vqbTotalDenum', 0] },
               null,
-              { $divide: ['$_tcAppArray.bar', '$_tcTotalDenum'] },
+              { $divide: ['$_vqbAppArray.bar', '$_vqbTotalDenum'] },
             ],
           },
-          _tcTotalDenum: 0,
+          _vqbTotalDenum: 0,
         },
       },
-      { $replaceRoot: { newRoot: { $mergeObjects: ['$_tcAppArray', '$$ROOT'] } } },
-      { $project: { _tcAppArray: 0 } },
+      { $replaceRoot: { newRoot: { $mergeObjects: ['$_vqbAppArray', '$$ROOT'] } } },
+      { $project: { _vqbAppArray: 0 } },
     ]);
   });
 
@@ -637,26 +637,26 @@ describe('Pipeline to mongo translator', () => {
       {
         $group: {
           _id: null,
-          _tcAppArray: { $push: '$$ROOT' },
-          _tcTotalDenum: { $sum: '$bar' },
+          _vqbAppArray: { $push: '$$ROOT' },
+          _vqbTotalDenum: { $sum: '$bar' },
         },
       },
-      { $unwind: '$_tcAppArray' },
+      { $unwind: '$_vqbAppArray' },
       {
         $project: {
           bar: {
             // we need to explicitely manage the case where '$total_denum' is null otherwise the query may just fail
             $cond: [
-              { $eq: ['$_tcTotalDenum', 0] },
+              { $eq: ['$_vqbTotalDenum', 0] },
               null,
-              { $divide: ['$_tcAppArray.bar', '$_tcTotalDenum'] },
+              { $divide: ['$_vqbAppArray.bar', '$_vqbTotalDenum'] },
             ],
           },
-          _tcTotalDenum: 0,
+          _vqbTotalDenum: 0,
         },
       },
-      { $replaceRoot: { newRoot: { $mergeObjects: ['$_tcAppArray', '$$ROOT'] } } },
-      { $project: { _tcAppArray: 0 } },
+      { $replaceRoot: { newRoot: { $mergeObjects: ['$_vqbAppArray', '$$ROOT'] } } },
+      { $project: { _vqbAppArray: 0 } },
     ]);
   });
 });


### PR DESCRIPTION
Adopt the following conventions:

- step types should be ordered alphabtically in `PipelineStep` definition,
- step transform callbacks should be ordered alphabetically in `BaseTranslator`.
- prefix internal and intermediate mongo fields with `_vqb`

Closes https://github.com/ToucanToco/vue-query-builder/issues/107