### PR TITLE
Fix ::  percentage step translation to mongo

### DIFF
--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -108,7 +108,7 @@ function transformPercentage(step: PercentageStep): Array<MongoStep> {
         { $divide: [`$_vqbAppArray.${step.column}`, '$_vqbTotalDenum'] },
       ],
     },
-    _vqbTotalDenum: 0, // We do not want to keep that column at the end
+    _vqbAppArray: 1, // we need to keep track of this key for the next operation
   };
 
   return [

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -617,7 +617,7 @@ describe('Pipeline to mongo translator', () => {
               { $divide: ['$_vqbAppArray.bar', '$_vqbTotalDenum'] },
             ],
           },
-          _vqbTotalDenum: 0,
+          _vqbAppArray: 1, // we need to keep track of this key for the next operation
         },
       },
       { $replaceRoot: { newRoot: { $mergeObjects: ['$_vqbAppArray', '$$ROOT'] } } },
@@ -652,7 +652,7 @@ describe('Pipeline to mongo translator', () => {
               { $divide: ['$_vqbAppArray.bar', '$_vqbTotalDenum'] },
             ],
           },
-          _vqbTotalDenum: 0,
+          _vqbAppArray: 1, // we need to keep track of this key for the next operation
         },
       },
       { $replaceRoot: { newRoot: { $mergeObjects: ['$_vqbAppArray', '$$ROOT'] } } },


### PR DESCRIPTION
We did not keep track of the _vqbAppArray and was source of error when the query is executed.

Also, we combined inclusion and exclusion of columns in a project, which is forbidden if exclusion does not concern the special _id key.

Related to https://github.com/ToucanToco/vue-query-builder/issues/68