### PR TITLE
Fix :: simplifyMongoPipeline

### DIFF
--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -233,8 +233,8 @@ export function _simplifyMongoPipeline(mongoSteps: Array<MongoStep>): Array<Mong
          * includes any inclusion, we do not want to merge those steps.
          */
         if (stepOperator === '$project') {
-          const excluded = Number(step['$project'][key] === 0);
-          merge = !Object.values(lastStep.$project).some(value => value === excluded);
+          const included = Boolean(step['$project'][key]);
+          merge = Object.values(lastStep.$project).every(value => value == included);
         }
         if (lastStep[stepOperator].hasOwnProperty(key)) {
           // We do not want to merge two $project with common keys

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -233,8 +233,8 @@ export function _simplifyMongoPipeline(mongoSteps: Array<MongoStep>): Array<Mong
          * includes any inclusion, we do not want to merge those steps.
          */
         if (stepOperator === '$project') {
-          const included = Boolean(step['$project'][key]);
-          merge = Object.values(lastStep.$project).every(value => value == included);
+          const included = Boolean(step.$project[key]);
+          merge = Object.values(lastStep.$project).every(value => Boolean(value) === included);
         }
         if (lastStep[stepOperator].hasOwnProperty(key)) {
           // We do not want to merge two $project with common keys

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -229,17 +229,12 @@ export function _simplifyMongoPipeline(mongoSteps: Array<MongoStep>): Array<Mong
       for (const key in step[stepOperator]) {
         /**
          * In Mongo, exclusions cannot be combined with any inclusion, so if we
-         * have such an exclusion in a $project step, and that the previous one
-         * include any inclusion, we do not want to merge the steps.
+         * have an exclusion in a $project step, and that the previous one
+         * includes any inclusion, we do not want to merge those steps.
          */
         if (stepOperator === '$project') {
-          const bool = step[stepOperator][key] === 0;
-          for (const lastKey in lastStep[stepOperator]) {
-            if (lastStep[stepOperator][lastKey] === Number(bool)) {
-              merge = false;
-              break;
-            }
-          }
+          const excluded = Number(step['$project'][key] === 0);
+          merge = !Object.values(lastStep.$project).some(value => value === excluded);
         }
         if (lastStep[stepOperator].hasOwnProperty(key)) {
           // We do not want to merge two $project with common keys

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -287,6 +287,7 @@ describe('Pipeline to mongo translator', () => {
       },
       { $project: { Region_bis: 0 } },
       { $project: { test: '$test' } },
+      { $project: { test: 2 } },
       { $project: { exclusion: 0 } },
       {
         $addFields: {
@@ -369,6 +370,7 @@ describe('Pipeline to mongo translator', () => {
         },
       },
       { $project: { test: '$test' } },
+      { $project: { test: 2 } },
       { $project: { exclusion: 0 } },
       {
         $addFields: {

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -173,6 +173,7 @@ describe('Pipeline to mongo translator', () => {
       { name: 'domain', domain: 'test_cube' },
       { name: 'filter', column: 'Manager', value: 'Pierre' },
       { name: 'delete', columns: ['Manager'] },
+      { name: 'delete', columns: ['Random'] },
       { name: 'select', columns: ['Country', 'Region', 'Population', 'Region_bis'] },
       { name: 'delete', columns: ['Region_bis'] },
       { name: 'newcolumn', column: 'id', query: { $concat: ['$Country', ' - ', '$Region'] } },
@@ -201,6 +202,11 @@ describe('Pipeline to mongo translator', () => {
       {
         $project: {
           Manager: 0,
+          Random: 0,
+        },
+      },
+      {
+        $project: {
           Country: 1,
           Region: 1,
           Population: 1,
@@ -270,6 +276,7 @@ describe('Pipeline to mongo translator', () => {
       { $match: { Manager: 'Pierre' } },
       { $match: { Manager: { $ne: 'NA' } } },
       { $project: { Manager: 0 } },
+      { $project: { Random: 0 } },
       {
         $project: {
           Country: 1,
@@ -342,6 +349,11 @@ describe('Pipeline to mongo translator', () => {
       {
         $project: {
           Manager: 0,
+          Random: 0,
+        },
+      },
+      {
+        $project: {
           Country: 1,
           Region: 1,
           Population: 1,

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -286,6 +286,8 @@ describe('Pipeline to mongo translator', () => {
         },
       },
       { $project: { Region_bis: 0 } },
+      { $project: { test: '$test' } },
+      { $project: { exclusion: 0 } },
       {
         $addFields: {
           id: { $concat: ['$Country', ' - ', '$Region'] },
@@ -366,6 +368,8 @@ describe('Pipeline to mongo translator', () => {
           Region_bis: 0,
         },
       },
+      { $project: { test: '$test' } },
+      { $project: { exclusion: 0 } },
       {
         $addFields: {
           id: { $concat: ['$Country', ' - ', '$Region'] },


### PR DESCRIPTION
Do not allow mix of inclusions ("\<column\>: <any expr != 0>") and exclusions ("\<column\>: 0") when trying to merge $project steps, as it source of error in Mongo

Closes #114