### PR TITLE
Feature:: 'argmax' and 'argmin' steps to mongo

### DIFF
--- a/doc/steps.md
+++ b/doc/steps.md
@@ -25,6 +25,156 @@ An aggreation step has the following strucure:
 }
 ```
 
+### `argmax` step
+
+Get row(s) matching the maximum value in a given `column`, by group if `groups`
+is specified.
+
+```javascript
+{
+    name: 'argmax';
+    column: 'value'; // column in which to search for max value
+    groups: Array<string>; // optional
+}
+```
+
+#### Example 1: without `groups`
+
+**Input dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| Label 1 | Group 1 | 13    |
+| Label 2 | Group 1 | 7     |
+| Label 3 | Group 1 | 20    |
+| Label 4 | Group 2 | 1     |
+| Label 5 | Group 2 | 10    |
+| Label 6 | Group 2 | 5     |
+
+**Step configuration:**
+
+```javascript
+{
+  {
+    name: 'argmax';
+    column: 'Value';
+  }
+}
+```
+
+**Output dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| Label 3 | Group 1 | 20    |
+
+#### Example 2: with `groups`
+
+**Input dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| Label 1 | Group 1 | 13    |
+| Label 2 | Group 1 | 7     |
+| Label 3 | Group 1 | 20    |
+| Label 4 | Group 2 | 1     |
+| Label 5 | Group 2 | 10    |
+| Label 6 | Group 2 | 5     |
+
+**Step configuration:**
+
+```javascript
+{
+  {
+    name: 'argmax';
+    column: 'Value';
+    groups: 'Group';
+  }
+}
+```
+
+**Output dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| Label 3 | Group 1 | 20    |
+| Label 5 | Group 2 | 10    |
+
+### `argmin` step
+
+Get row(s) matching the minimum value in a given `column`, by group if `groups`
+is specified.
+
+```javascript
+{
+    name: 'argmin';
+    column: 'value'; // column in which to search for max value
+    groups: Array<string>; // optional
+}
+```
+
+#### Example 1: without `groups`
+
+**Input dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| Label 1 | Group 1 | 13    |
+| Label 2 | Group 1 | 7     |
+| Label 3 | Group 1 | 20    |
+| Label 4 | Group 2 | 1     |
+| Label 5 | Group 2 | 10    |
+| Label 6 | Group 2 | 5     |
+
+**Step configuration:**
+
+```javascript
+{
+  {
+    name: 'argmin';
+    column: 'Value';
+  }
+}
+```
+
+**Output dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| Label 2 | Group 1 | 7     |
+
+#### Example 2: with `groups`
+
+**Input dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| Label 1 | Group 1 | 13    |
+| Label 2 | Group 1 | 7     |
+| Label 3 | Group 1 | 20    |
+| Label 4 | Group 2 | 1     |
+| Label 5 | Group 2 | 10    |
+| Label 6 | Group 2 | 5     |
+
+**Step configuration:**
+
+```javascript
+{
+  {
+    name: 'argmin';
+    column: 'Value';
+    groups: 'Group';
+  }
+}
+```
+
+**Output dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| Label 2 | Group 1 | 7     |
+| Label 4 | Group 2 | 1     |
+
 ### `custom` step
 
 This step allows to define a custom query that can't be expressed using the

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -16,9 +16,9 @@ An aggreation step has the following strucure:
    on: ['column1', 'column2'],
    aggregations:  [
       {
-          newcolumn: 'sum_value1'
-          aggfunction: 'sum'
-          column: 'value1',
+          newcolumn: 'sum_value1',
+          aggfunction: 'sum',
+          column: 'value1'
       }
     // ...
   ]
@@ -32,9 +32,9 @@ is specified.
 
 ```javascript
 {
-    name: 'argmax';
-    column: 'value'; // column in which to search for max value
-    groups: Array<string>; // optional
+    name: 'argmax',
+    column: 'value', // column in which to search for max value
+    groups: ['group1', 'group2']
 }
 ```
 
@@ -56,8 +56,8 @@ is specified.
 ```javascript
 {
   {
-    name: 'argmax';
-    column: 'Value';
+    name: 'argmax',
+    column: 'Value'
   }
 }
 ```
@@ -86,9 +86,9 @@ is specified.
 ```javascript
 {
   {
-    name: 'argmax';
-    column: 'Value';
-    groups: 'Group';
+    name: 'argmax',
+    column: 'Value',
+    groups: ['Group']
   }
 }
 ```
@@ -107,9 +107,9 @@ is specified.
 
 ```javascript
 {
-    name: 'argmin';
-    column: 'value'; // column in which to search for max value
-    groups: Array<string>; // optional
+  name: 'argmin',
+  column: 'value', // column in which to search for max value
+  groups: ['group1', 'group2'] // optional
 }
 ```
 
@@ -131,8 +131,8 @@ is specified.
 ```javascript
 {
   {
-    name: 'argmin';
-    column: 'Value';
+    name: 'argmin',
+    column: 'Value'
   }
 }
 ```
@@ -161,9 +161,9 @@ is specified.
 ```javascript
 {
   {
-    name: 'argmin';
-    column: 'Value';
-    groups: 'Group';
+    name: 'argmin',
+    column: 'Value',
+    groups: ['Groups']
   }
 }
 ```
@@ -183,7 +183,7 @@ other existing steps.
 ```javascript
 {
     name: 'custom',
-    query: '$group: {_id: ...}',
+    query: '$group: {_id: ...}'
 }
 ```
 
@@ -229,7 +229,7 @@ Filter out lines that don't match a filter definition.
 {
     name: 'filter',
     column: 'my-column',
-    value: 42
+    value: 42,
     operator: 'ne'
 }
 ```
@@ -290,7 +290,7 @@ A replace step has the following strucure:
    search_column: "column_1",
    new_column: "column_1", // if empty, inplace by default
    oldvalue: 'foo',
-   newvalue: 'bar',
+   newvalue: 'bar'
 }
 ```
 

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -21,6 +21,12 @@ export type AggregationStep = Readonly<{
   aggregations: Array<AggFunctionStep>;
 }>;
 
+export type ArgmaxStep = Readonly<{
+  name: 'argmax';
+  column: string; // column in which to search for max value
+  groups?: Array<string>; // if specified, will search for a max in every group
+}>;
+
 export type CustomStep = Readonly<{
   name: 'custom';
   query: object;
@@ -97,6 +103,7 @@ export type TopStep = Readonly<{
 
 export type PipelineStep =
   | AggregationStep
+  | ArgmaxStep
   | CustomStep
   | DeleteStep
   | DomainStep

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -27,6 +27,12 @@ export type ArgmaxStep = Readonly<{
   groups?: Array<string>; // if specified, will search for a max in every group
 }>;
 
+export type ArgminStep = Readonly<{
+  name: 'argmin';
+  column: string; // column in which to search for max value
+  groups?: Array<string>; // if specified, will search for a max in every group
+}>;
+
 export type CustomStep = Readonly<{
   name: 'custom';
   query: object;
@@ -104,6 +110,7 @@ export type TopStep = Readonly<{
 export type PipelineStep =
   | AggregationStep
   | ArgmaxStep
+  | ArgminStep
   | CustomStep
   | DeleteStep
   | DomainStep

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -90,6 +90,9 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
   aggregate(step: S.AggregationStep) {}
 
   @unsupported
+  argmax(step: S.ArgmaxStep) {}
+
+  @unsupported
   custom(step: S.CustomStep) {}
 
   @unsupported

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -93,6 +93,9 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
   argmax(step: S.ArgmaxStep) {}
 
   @unsupported
+  argmin(step: S.ArgminStep) {}
+
+  @unsupported
   custom(step: S.CustomStep) {}
 
   @unsupported

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -94,7 +94,7 @@ function transformArgmaxArgmin(step: ArgmaxStep | ArgminStep): Array<MongoStep> 
   } else {
     groupCols = null;
   }
-  groupMongo['$group'] = {
+  groupMongo.$group = {
     _id: groupCols,
     _vqbAppArray: { $push: '$$ROOT' },
     _vqbAppValueToCompare: { [stepMapping[step.name]]: `$${step.column}` },


### PR DESCRIPTION
Those steps return row(s) matching the maximum (for `argmax`) or minimum (for `argmin`) value in a given `column`, by group if `groups` is specified.

```javascript
{
    name: 'argmin';
    column: 'value'; // column in which to search for max value
    groups: Array<string>; // optional
}
```

Closes https://github.com/ToucanToco/vue-query-builder/issues/65