### PR TITLE
Feature:: 'pivot' step translation to mongo

### DIFF
--- a/doc/steps.md
+++ b/doc/steps.md
@@ -266,6 +266,58 @@ group: ['foo'] // optional
 
 `value` can be an arbitrary value (e.g a list when used with the `in` operator)
 
+### `pivot` step
+
+Pivot rows into columns around a given `index` (expressed as a combination of column(s)).
+Values to be used as new column names are found in the column `column_to_pivot`.
+Values to populate new columns are found in the column `value_column`.
+The function used to aggregate data (when several rows are found by index group) must be
+among `sum`, `avg`, `count`, `min` or `max`.
+
+```javascript
+{
+  name: 'pivot',
+  index: ['column_1', 'column_2'],
+  column_to_pivot: 'column_3',
+  value_column: 'column_4',
+  agg_function: 'sum',
+}
+```
+
+#### Example:
+
+**Input dataset:**
+
+| Label   | Country  | Value |
+| ------- | -------- | ----- |
+| Label 1 | Country1 | 13    |
+| Label 2 | Country1 | 7     |
+| Label 3 | Country1 | 20    |
+| Label 1 | Country2 | 1     |
+| Label 2 | Country2 | 10    |
+| Label 3 | Country2 | 5     |
+| label 3 | Country2 | 1     |
+
+**Step configuration:**
+
+```javascript
+{
+  name: 'pivot',
+  index: ['Label'],
+  column_to_pivot: 'Country',
+  value_column: 'Value',
+  agg_function: 'sum',
+}
+```
+
+**Output dataset:**
+
+| Label   | Country1 | Country2 |
+| ------- | -------- | -------- |
+| Label 1 | 13       | 1        |
+| Label 2 | 7        | 10       |
+| Label 3 | 20       | 6        |
+
 ### `rename` step
 
 Rename a column.,

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -74,6 +74,15 @@ export type PercentageStep = Readonly<{
   group?: Array<string>;
 }>;
 
+export type PivotStep = Readonly<{
+  name: 'pivot';
+  index: ['column_1', 'column_2']; // fixed column(s) around which to pivot data
+  column_to_pivot: 'column_3';
+  value_column: 'column_4'; // value column to be used to populate pivoted column
+  // function used to aggregate data when several rows are found by index group
+  agg_function: 'sum' | 'avg' | 'count' | 'min' | 'max';
+}>;
+
 export type RenameStep = Readonly<{
   name: 'rename';
   oldname: string;
@@ -118,6 +127,7 @@ export type PipelineStep =
   | FilterStep
   | NewColumnStep
   | PercentageStep
+  | PivotStep
   | RenameStep
   | ReplaceStep
   | SelectStep

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -76,10 +76,9 @@ export type PercentageStep = Readonly<{
 
 export type PivotStep = Readonly<{
   name: 'pivot';
-  index: ['column_1', 'column_2']; // fixed column(s) around which to pivot data
+  index: ['column_1', 'column_2'];
   column_to_pivot: 'column_3';
-  value_column: 'column_4'; // value column to be used to populate pivoted column
-  // function used to aggregate data when several rows are found by index group
+  value_column: 'column_4';
   agg_function: 'sum' | 'avg' | 'count' | 'min' | 'max';
 }>;
 

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -117,6 +117,9 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
   percentage(step: S.PercentageStep) {}
 
   @unsupported
+  pivot(step: S.PivotStep) {}
+
+  @unsupported
   rename(step: S.RenameStep) {}
 
   @unsupported


### PR DESCRIPTION
Pivot rows into columns around a given `index` (expressed as a combination of column(s)).
Values to be used as new column names are found in the column `column_to_pivot`.
Values to populate new columns are found in the column `value_column`.
The function used to aggregate data (when several rows are found by index group) must be
among `sum`, `avg`, `count`, `min` or `max`.

```javascript
{
  name: 'pivot',
  index: ['column_1', 'column_2'],
  column_to_pivot: 'column_3',
  value_column: 'column_4',
  agg_function: 'sum',
}
```

Closes https://github.com/ToucanToco/vue-query-builder/issues/64