### PR TITLE
Feature:: 'pivot' step translation to mongo

### DIFF
--- a/doc/steps.md
+++ b/doc/steps.md
@@ -234,6 +234,11 @@ Filter out lines that don't match a filter definition.
 }
 ```
 
+`operator` is optional, and defaults to `eq`. Allowed operators are `eq`, `ne`,
+`gt`, `ge`, `lt`, `le`, `in`, `nin`.
+
+`value` can be an arbitrary value (e.g a list when used with the `in` operator)
+
 ### `formula` step
 
 Filter out lines that don't match a filter definition.
@@ -290,10 +295,57 @@ group: ['foo'] // optional
 }
 ```
 
-`operator` is optional, and defaults to `eq`. Allowed operators are `eq`, `ne`,
-`gt`, `ge`, `lt`, `le`, `in`, `nin`.
+### `pivot` step
 
-`value` can be an arbitrary value (e.g a list when used with the `in` operator)
+Pivot rows into columns around a given `index` (expressed as a combination of column(s)).
+Values to be used as new column names are found in the column `column_to_pivot`.
+Values to populate new columns are found in the column `value_column`.
+The function used to aggregate data (when several rows are found by index group) must be
+among `sum`, `avg`, `count`, `min` or `max`.
+
+```javascript
+{
+ name: 'pivot',
+ index: ['column_1', 'column_2'],
+ column_to_pivot: 'column_3',
+ value_column: 'column_4',
+ agg_function: 'sum',
+}
+```
+
+#### Example:
+
+**Input dataset:**
+
+| Label   | Country  | Value |
+| ------- | -------- | ----- |
+| Label 1 | Country1 | 13    |
+| Label 2 | Country1 | 7     |
+| Label 3 | Country1 | 20    |
+| Label 1 | Country2 | 1     |
+| Label 2 | Country2 | 10    |
+| Label 3 | Country2 | 5     |
+| label 3 | Country2 | 1     |
+
+**Step configuration:**
+
+```javascript
+{
+ name: 'pivot',
+ index: ['Label'],
+ column_to_pivot: 'Country',
+ value_column: 'Value',
+ agg_function: 'sum',
+}
+```
+
+**Output dataset:**
+
+| Label   | Country1 | Country2 |
+| ------- | -------- | -------- |
+| Label 1 | 13       | 1        |
+| Label 2 | 7        | 10       |
+| Label 3 | 20       | 6        |
 
 ### `rename` step
 

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -54,6 +54,12 @@ export type FillnaStep = Readonly<{
   value: PrimitiveType;
 }>;
 
+export type FormulaStep = Readonly<{
+  name: 'formula';
+  new_column: string;
+  formula: string;
+}>;
+
 export type FilterStep = Readonly<{
   name: 'filter';
   column: string;
@@ -66,6 +72,14 @@ export type PercentageStep = Readonly<{
   new_column?: string;
   column: string;
   group?: Array<string>;
+}>;
+
+export type PivotStep = Readonly<{
+  name: 'pivot';
+  index: ['column_1', 'column_2'];
+  column_to_pivot: 'column_3';
+  value_column: 'column_4';
+  agg_function: 'sum' | 'avg' | 'count' | 'min' | 'max';
 }>;
 
 export type RenameStep = Readonly<{
@@ -101,12 +115,6 @@ export type TopStep = Readonly<{
   limit: number;
 }>;
 
-export type FormulaStep = Readonly<{
-  name: 'formula';
-  new_column: string;
-  formula: string;
-}>;
-
 export type PipelineStep =
   | AggregationStep
   | ArgmaxStep
@@ -118,6 +126,7 @@ export type PipelineStep =
   | FilterStep
   | FormulaStep
   | PercentageStep
+  | PivotStep
   | RenameStep
   | ReplaceStep
   | SelectStep

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -117,6 +117,9 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
   percentage(step: S.PercentageStep) {}
 
   @unsupported
+  pivot(step: S.PivotStep) {}
+
+  @unsupported
   rename(step: S.RenameStep) {}
 
   @unsupported

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -6,6 +6,7 @@ import {
   ArgminStep,
   FilterStep,
   PipelineStep,
+  PivotStep,
   ReplaceStep,
   SortStep,
   TopStep,
@@ -171,6 +172,75 @@ function transformPercentage(step: PercentageStep): Array<MongoStep> {
   ];
 }
 
+/** transform an 'pivot' step into corresponding mongo steps */
+function transformPivot(step: PivotStep): Array<MongoStep> {
+  let groupCols1: PropMap<string> = {};
+  let groupCols2: PropMap<string> = {};
+  let addFieldsStep: PropMap<string> = {};
+
+  // Prepare groupCols to populate the `_id` field sof Mongo `$group` steps and addFields step
+  for (const col of step.index) {
+    groupCols1[col] = `$${col}`;
+    groupCols2[col] = `$_id.${col}`;
+    addFieldsStep[`_vqbAppTmpObj.${col}`] = `$_id.${col}`;
+  }
+
+  return [
+    /**
+     * First we perform the aggregation with the _id including the column to pivot
+     */
+    {
+      $group: {
+        _id: { ...groupCols1, [step.column_to_pivot]: `$${step.column_to_pivot}` },
+        [step.value_column]: { [`$${step.agg_function}`]: `$${step.value_column}` },
+      },
+    },
+    /**
+     * Then we group with with index columns as _id and we push documents as an array of sets
+     * including a column for the column to pivot and a column for the corresponding value
+     */
+    {
+      $group: {
+        _id: groupCols2,
+        _vqbAppArray: {
+          $addToSet: {
+            [step.column_to_pivot]: `$_id.${step.column_to_pivot}`,
+            [step.value_column]: `$${step.value_column}`,
+          },
+        },
+      },
+    },
+    /**
+     * Then we project a tmp key to get an object from the array of couples [column_to_pivot, corresponding_value]
+     * including a column for the column to pivot and a column for the corresponding value
+     */
+    {
+      $project: {
+        _vqbAppTmpObj: {
+          $arrayToObject: {
+            $zip: {
+              inputs: [
+                `$_vqbAppArray.${step.column_to_pivot}`,
+                `$_vqbAppArray.${step.value_column}`,
+              ],
+            },
+          },
+        },
+      },
+    },
+    /**
+     * Then we include back in every document created in the previous step the index columns
+     * (still accessible in the _id object)
+     */
+    { $addFields: addFieldsStep },
+    /**
+     * Then we replace the root of the documents tree to get our columns ready for
+     * our needed table-like, unnested format
+     */
+    { $replaceRoot: { newRoot: '$_vqbAppTmpObj' } },
+  ];
+}
+
 /** transform an 'replace' step into corresponding mongo steps */
 function transformReplace(step: ReplaceStep): MongoStep {
   return {
@@ -285,6 +355,7 @@ const mapper: StepMatcher<MongoStep> = {
     },
   }),
   percentage: transformPercentage,
+  pivot: transformPivot,
   rename: step => [
     { $addFields: { [step.newname]: `$${step.oldname}` } },
     { $project: { [step.oldname]: 0 } },

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -927,4 +927,59 @@ describe('Pipeline to mongo translator', () => {
       },
     ]);
   });
+
+  it('can generate a pivot step', () => {
+    const pipeline: Array<PipelineStep> = [
+      {
+        name: 'pivot',
+        index: ['column_1', 'column_2'],
+        column_to_pivot: 'column_3',
+        value_column: 'column_4',
+        agg_function: 'sum',
+      },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      {
+        $group: {
+          _id: {
+            column_1: '$column_1',
+            column_2: '$column_2',
+            column_3: '$column_3',
+          },
+          column_4: { $sum: '$column_4' },
+        },
+      },
+      {
+        $group: {
+          _id: {
+            column_1: '$_id.column_1',
+            column_2: '$_id.column_2',
+          },
+          _vqbAppArray: {
+            $addToSet: {
+              column_3: '$_id.column_3',
+              column_4: '$column_4',
+            },
+          },
+        },
+      },
+      {
+        $project: {
+          _vqbAppTmpObj: {
+            $arrayToObject: {
+              $zip: { inputs: ['$_vqbAppArray.column_3', '$_vqbAppArray.column_4'] },
+            },
+          },
+        },
+      },
+      {
+        $addFields: {
+          '_vqbAppTmpObj.column_1': '$_id.column_1',
+          '_vqbAppTmpObj.column_2': '$_id.column_2',
+        },
+      },
+      { $replaceRoot: { newRoot: '$_vqbAppTmpObj' } },
+    ]);
+  });
 });


### PR DESCRIPTION
Pivot rows into columns around a given `index` (expressed as a combination of column(s)).
Values to be used as new column names are found in the column `column_to_pivot`.
Values to populate new columns are found in the column `value_column`.
The function used to aggregate data (when several rows are found by index group) must be
among `sum`, `avg`, `count`, `min` or `max`.

```javascript
{
  name: 'pivot',
  index: ['column_1', 'column_2'],
  column_to_pivot: 'column_3',
  value_column: 'column_4',
  agg_function: 'sum',
}
```

Closes https://github.com/ToucanToco/vue-query-builder/issues/64