### PR TITLE
[rollup] make sure `mathjs.parse` is exported

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,9 @@ export default {
   ],
   plugins: [
     resolve(),
-    commonjs(),
+    commonjs({
+      namedExports: { 'node_modules/mathjs/index.js': ['parse'] },
+    }),
     css({
       output: 'dist/vue-query-builder.css'
     }),


### PR DESCRIPTION
`mathjs` is packaged in a way that makes `rollup-plugin-commonjs` unable
to identify which symbols should be exported, hence the following warning
we get at bundling time:

```
parse is not exported by node_modules/mathjs/index.js
331:         return ({
332:             $addFields: (_a = {},
333:                 _a[step.new_column] = buildMongoFormulaTree(math.parse(step.formula)),
                                                                      ^
334:                 _a),
335:         });
```

Therefore, `mathjs.parse` will end up being `undefined`.
To solve this problem, we can give the following hint to `rollup`:

```javascript
    commonjs({
      namedExports: { 'node_modules/mathjs/index.js': ['parse'] },
    }),
```

and `rollup` will do the necessary to export the symbol.