### PR TITLE
[eslint] set prefer-const and no-console rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,20 @@
       "eslint:recommended",
       "@vue/typescript"
     ],
-    "rules": {},
+    "rules": {
+      "prefer-const": [
+        "error"
+      ],
+      "no-console": [
+        "error",
+        {
+          "allow": [
+            "warn",
+            "error"
+          ]
+        }
+      ]
+    },
     "parserOptions": {
       "parser": "typescript-eslint-parser"
     }

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -164,8 +164,8 @@ function transformPercentage(step: PercentageStep): Array<MongoStep> {
 
 /** transform an 'pivot' step into corresponding mongo steps */
 function transformPivot(step: PivotStep): Array<MongoStep> {
-  let groupCols2: PropMap<string> = {};
-  let addFieldsStep: PropMap<string> = {};
+  const groupCols2: PropMap<string> = {};
+  const addFieldsStep: PropMap<string> = {};
 
   // Prepare groupCols to populate the `_id` field sof Mongo `$group` steps and addFields step
   for (const col of step.index) {


### PR DESCRIPTION
- make sure we use `const` if identifier is not reassigned (and fix the
two corresponding errors in `mongo.ts`)

- allow `console.warn` and `console.error`

Closes #128 