### PR TITLE
[store] introduce MutationCallbacks type

### DIFF
--- a/playground/App.vue
+++ b/playground/App.vue
@@ -18,7 +18,8 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { Getter, Mutation, State } from 'vuex-class';
-import { VQBState, activePipeline } from '@/store/state';
+import { activePipeline } from '@/store/state';
+import { MutationCallbacks } from '@/store/mutations';
 import { Pipeline, PipelineStep } from '@/lib/steps';
 import { DataSet } from '@/lib/dataset';
 import { MongoResults, mongoResultsToDataset } from '@/lib/dataset/mongo';
@@ -47,9 +48,9 @@ export default class App extends Vue {
 
   @Getter activePipeline!: Pipeline;
 
-  @Mutation setDomains!: (payload: Pick<VQBState, 'domains'>) => void;
-  @Mutation setPipeline!: (payload: Pick<VQBState, 'pipeline'>) => void;
-  @Mutation setDataset!: (payload: Pick<VQBState, 'dataset'>) => void;
+  @Mutation setDomains!: MutationCallbacks['setDomains'];
+  @Mutation setPipeline!: MutationCallbacks['setPipeline'];
+  @Mutation setDataset!: MutationCallbacks['setDataset'];
 
   isEditingStep: boolean = false;
   initialValue: any = undefined;

--- a/src/components/DomainSelector.vue
+++ b/src/components/DomainSelector.vue
@@ -18,7 +18,7 @@
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
 import { Mutation, State } from 'vuex-class';
-import { VQBState } from '@/store/state';
+import { MutationCallbacks } from '@/store/mutations';
 
 @Component({
   name: 'domain-selector'
@@ -29,7 +29,7 @@ export default class DomainSelector extends Vue {
   @Prop()
   readonly selectedDomain!: string | undefined
 
-  @Mutation setCurrentDomain!: (payload: Pick<VQBState, 'currentDomain'>) => void;
+  @Mutation setCurrentDomain!: MutationCallbacks['setCurrentDomain'];
 
   isDomainSelected(name: string) {
     return this.selectedDomain === name;

--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -30,7 +30,7 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Getter, Mutation, State } from 'vuex-class';
-import { VQBState } from '@/store/state';
+import { MutationCallbacks } from '@/store/mutations';
 import { DomainStep, Pipeline } from '@/lib/steps';
 import DomainSelector from './DomainSelector.vue';
 import Step from './Step.vue';
@@ -53,10 +53,10 @@ export default class PipelineComponent extends Vue {
   @Getter stepsWithoutDomain!: Pipeline;
   @Getter('isStepDisabled') isDisabled!: (index: number) => boolean;
 
-  @Mutation selectStep!: (payload: Pick<VQBState, 'selectedStepIndex'>) => void;
+  @Mutation selectStep!: MutationCallbacks['selectStep'];
 
   resetSelectedStep() {
-    this.selectStep({ selectedStepIndex: -1 });
+    this.selectStep({ index: -1 });
   }
 }
 </script>

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -25,7 +25,7 @@ import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { Mutation } from 'vuex-class';
 import { PipelineStep } from '@/lib/steps';
-import { VQBState } from '@/store/state';
+import { MutationCallbacks } from '@/store/mutations';
 
 @Component({
   name: 'step',
@@ -49,7 +49,7 @@ export default class Step extends Vue {
   @Prop()
   readonly indexInPipeline!: number;
 
-  @Mutation deleteStep!: (payload: { index: number }) => void;
+  @Mutation deleteStep!: MutationCallbacks['deleteStep'];
 
   get classDot() {
     return {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -38,11 +38,16 @@ type SelectedStepMutation = {
 
 export type StateMutation =
   | DatasetMutation
-  | DomainsMutation
   | DeleteStepMutation
+  | DomainsMutation
   | PipelineMutation
   | SelectDomainMutation
   | SelectedStepMutation;
+
+type MutationByType<M, MT> = M extends { type: MT } ? M : never;
+export type MutationCallbacks = {
+  [K in StateMutation['type']]: (payload: MutationByType<StateMutation, K>['payload']) => void
+};
 
 export default {
   /**


### PR DESCRIPTION
This type should provide easy entry points to describe mutation callback
types. For instance, instead of writing:

```typescript
@Mutation setDomains!: (payload: Pick<VQBState, 'domains'>) => void;
```

you can now write:

```typescript
@Mutation setDomains!: MutationCallbacks['setDomains'];
```