### PR TITLE
[playground] narrow transpilation to the bare minimum

### DIFF
--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig",
-  "include": ["*.ts"],
-  "exclude": ["main.ts"],
+  "include": ["server.ts"],
   "compilerOptions": {
     "module": "commonjs"
   }


### PR DESCRIPTION
We only need to transpile `server.ts`, not all typescript modules found
in the directory.