### PR TITLE
Feature :: Action Menu on DataViewer's header cells

### DIFF
--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -1,0 +1,111 @@
+<template>
+  <popover :active="isActive" :align="alignLeft" bottom>
+    <div class="action-menu__body">
+      <div class="action-menu__section">
+        <div class="action-menu__option">Duplicate column</div>
+        <div class="action-menu__option" @click="createRenameStep">Rename column</div>
+        <div class="action-menu__option">Delete column</div>
+      </div>
+    </div>
+  </popover>
+</template>
+<script lang="ts">
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { POPOVER_ALIGN } from '@/components/constants';
+import Popover from './Popover.vue';
+
+@Component({
+  name: 'action-menu',
+  components: {
+    Popover,
+  },
+})
+export default class ActionMenu extends Vue {
+  @Prop({
+    type: Boolean,
+    default: () => false,
+  })
+  isActive!: boolean;
+
+  @Prop({
+    type: String,
+    default: () => '',
+  })
+  columnName!: string;
+
+  alignLeft: string = POPOVER_ALIGN.LEFT;
+
+  /**
+   * @description Close the popover when clicking outside
+   */
+  clickListener(e: Event) {
+    const hasClickOnItSelf = e.target === this.$el || this.$el.contains(e.target as HTMLElement);
+
+    if (!hasClickOnItSelf) {
+      this.close();
+    }
+  }
+
+  close() {
+    this.$emit('closed');
+  }
+
+  createRenameStep() {
+    this.$emit('actionClicked', { name: 'rename', oldname: this.columnName });
+    this.close();
+  }
+
+  @Watch('isActive')
+  onIsActiveChanged(val: boolean, oldval: boolean) {
+    if (val) {
+      window.addEventListener('click', this.clickListener);
+    } else {
+      window.removeEventListener('click', this.clickListener);
+    }
+  }
+}
+</script>
+<style lang="scss">
+@import '../styles/_variables';
+
+.action-menu__body {
+  display: flex;
+  flex-direction: column;
+  border-radius: 3px;
+  margin-left: -5px;
+  margin-right: -5px;
+  width: 200px;
+  background-color: #fff;
+  box-shadow: 0px 1px 20px 0px rgba(0, 0, 0, 0.2);
+}
+
+.action-menu__section {
+  display: flex;
+  flex-direction: column;
+  border-color: $data-viewer-border-color;
+
+  &:not(:last-child) {
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+  }
+}
+
+.action-menu__option {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 10px 12px;
+  line-height: 20px;
+  justify-content: space-between;
+  position: relative;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.03);
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+</style>

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -84,15 +84,15 @@ export default class DataViewer extends Vue {
    */
   get formattedColumns() {
     return this.columnNames.map((d, index) => {
-      let isActive = false;
+      let isActionMenuOpened = false;
 
       if (index === this.indexActiveActionMenu) {
-        isActive = true;
+        isActionMenuOpened = true;
       }
 
       return {
         name: d,
-        isActionMenuOpened: isActive,
+        isActionMenuOpened,
         class: {
           'data-viewer__header-cell': true,
           'data-viewer__header-cell--active': this.isSelected(d),

--- a/src/components/FormRenameStep.vue
+++ b/src/components/FormRenameStep.vue
@@ -122,7 +122,7 @@ export default class FormRenameStep extends Mixins(FormMixin) {
 }
 
 .widget-form-action__button--validate {
-  background: $blue;
+  background-color: $active-color;
 }
 
 .step-edit-form {

--- a/src/components/FormRenameStep.vue
+++ b/src/components/FormRenameStep.vue
@@ -9,7 +9,6 @@
       name="Old name"
       :options="columnNames"
       placeholder="Enter the old column name"
-      @input="toggleColumnSelection(step.oldname)"
     ></WidgetAutocomplete>
     <WidgetInputText
       id="newnameInput"
@@ -79,7 +78,7 @@ export default class FormRenameStep extends Mixins(FormMixin) {
   @State selectedStepIndex!: number;
 
   @Mutation selectStep!: (payload: { index: number }) => void;
-  @Mutation toggleColumnSelection!: (column: string) => void;
+  @Mutation toggleColumnSelection!: (payload: { column: string }) => void;
 
   @Getter selectedColumns!: string[];
   @Getter columnNames!: string[];
@@ -92,9 +91,16 @@ export default class FormRenameStep extends Mixins(FormMixin) {
     }
   }
 
+  @Watch('step.oldname')
+  onOldNameChanged(val: string, oldVal: string) {
+    if (val !== oldVal && !_.isEqual(this.selectedColumns, [val])) {
+      this.toggleColumnSelection({ column: val });
+    }
+  }
+
   created() {
     this.schema = renameSchema;
-    this.toggleColumnSelection(this.initialValue.oldname);
+    this.toggleColumnSelection({ column: this.initialValue.oldname });
   }
 
   validateStep() {

--- a/src/components/FormRenameStep.vue
+++ b/src/components/FormRenameStep.vue
@@ -8,6 +8,7 @@
       v-model="step.oldname"
       name="Old name"
       :options="columnNames"
+      @input="setSelectedColumns({ column: step.oldname })"
       placeholder="Enter the old column name"
     ></WidgetAutocomplete>
     <WidgetInputText
@@ -72,13 +73,13 @@ export default class FormRenameStep extends Mixins(FormMixin) {
   })
   isStepCreation!: boolean;
 
-  step: RenameStepConf = this.initialValue;
+  step: RenameStepConf = { ...this.initialValue };
 
   @State pipeline!: Pipeline;
   @State selectedStepIndex!: number;
 
   @Mutation selectStep!: (payload: { index: number }) => void;
-  @Mutation toggleColumnSelection!: (payload: { column: string }) => void;
+  @Mutation setSelectedColumns!: (payload: { column: string }) => void;
 
   @Getter selectedColumns!: string[];
   @Getter columnNames!: string[];
@@ -90,17 +91,10 @@ export default class FormRenameStep extends Mixins(FormMixin) {
       this.step.oldname = val[0];
     }
   }
-
-  @Watch('step.oldname')
-  onOldNameChanged(val: string, oldVal: string) {
-    if (val !== oldVal && !_.isEqual(this.selectedColumns, [val])) {
-      this.toggleColumnSelection({ column: val });
-    }
-  }
-
+  
   created() {
     this.schema = renameSchema;
-    this.toggleColumnSelection({ column: this.initialValue.oldname });
+    this.setSelectedColumns({ column: this.initialValue.oldname });
   }
 
   validateStep() {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -104,15 +104,24 @@ export default {
   },
 
   /**
-   * toggle column selection
+   *
+   * set selected columns
    */
-  toggleColumnSelection(state: VQBState, column: string) {
+  setSelectedColumns(state: VQBState, { column }: { column: string }) {
     state.selectedColumns = [column];
   },
 
   /**
    * toggle column selection
    */
+  toggleColumnSelection(state: VQBState, { column }: { column: string }) {
+    if (state.selectedColumns.includes(column)) {
+      state.selectedColumns = [];
+    } else {
+      state.selectedColumns = [column];
+    }
+  },
+
   toggleStepEdition(state: VQBState) {
     state.isEditingStep = !state.isEditingStep;
   },

--- a/src/styles/DataViewer.scss
+++ b/src/styles/DataViewer.scss
@@ -26,6 +26,7 @@
   flex-grow: 1;
   flex-shrink: 0;
   justify-content: space-between;
+  align-items: center;
 }
 
 .data-viewer-cell {
@@ -59,6 +60,10 @@
   border-top-color: $active-color;
   border-left-color: $active-color;
   border-right-color: $active-color;
+
+  .data-viewer__header-action:hover {
+    background-color: $active-color-faded;
+  }
 }
 
 .data-viewer__header-label {
@@ -73,9 +78,26 @@
   opacity: 0;
   visibility: hidden;
   position: absolute;
+  font-size: 18px;
   right: 10px;
   top: 8px;
   transition: opacity 300ms ease;
+  display: flex;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  align-items: center;
+  justify-content: center;
+}
+
+.data-viewer__header-action:hover {
+  background-color: $data-viewer-border-color;
+}
+
+.data-viewer__header-action--visible {
+  opacity: 1;
+  visibility: visible;
+  background-color: $active-color-faded;
 }
 
 .data-viewer__header-cell:hover {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -8,7 +8,6 @@ $active-color: rgb(38, 101, 163) !default;
 $active-color-faded: rgba($active-color, 0.1) !default;
 $active-color-faded-2: rgba($active-color, 0.05) !default;
 $data-viewer-border-color: #e0e0e0 !default;
-$blue: #2665a3;
 $grey: #eeeeee;
 
 //GLOBAL STYLE
@@ -22,6 +21,10 @@ body {
   color: $base-color;
   font-family: 'Montserrat', sans-serif;
   margin: 0;
+}
+
+button {
+  outline: none;
 }
 
 // FORMS STYLES PLACEHOLDER

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -1,0 +1,52 @@
+import { mount } from '@vue/test-utils';
+import ActionMenu from '@/components/ActionMenu.vue';
+
+describe('Action Menu', () => {
+  it('should instantiate with its popover hidden', () => {
+    const wrapper = mount(ActionMenu);
+
+    expect(wrapper.exists()).toBeTruthy();
+    expect(wrapper.classes()).toContain('popover');
+  });
+
+  it('should instantiate with the popover active', () => {
+    const wrapper = mount(ActionMenu, {
+      propsData: {
+        isActive: true,
+      },
+    });
+
+    expect(wrapper.classes()).toContain('popover--active');
+  });
+
+  describe('when click on "Rename column"', () => {
+    it('should have an "Rename column" action', () => {
+      const wrapper = mount(ActionMenu);
+      const actionsWrapper = wrapper.findAll('.action-menu__option');
+
+      expect(actionsWrapper.at(1).text()).toEqual('Rename column');
+    });
+
+    it('should emit an "actionClicked" event', () => {
+      const wrapper = mount(ActionMenu);
+      const actionsWrapper = wrapper.findAll('.action-menu__option');
+      actionsWrapper.at(1).trigger('click');
+
+      expect(wrapper.emitted().actionClicked).toBeTruthy();
+    });
+
+    it('shoud emit an "actionClicked" with the oldname already filled', () => {
+      const wrapper = mount(ActionMenu, {
+        propsData: {
+          columnName: 'dreamfall',
+        },
+      });
+      const actionsWrapper = wrapper.findAll('.action-menu__option');
+      actionsWrapper.at(1).trigger('click');
+
+      expect(wrapper.emitted().actionClicked[0]).toEqual([
+        { name: 'rename', oldname: 'dreamfall' },
+      ]);
+    });
+  });
+});

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -19,14 +19,12 @@ describe('Action Menu', () => {
     expect(wrapper.classes()).toContain('popover--active');
   });
 
+  it('should have an "Rename column" action', () => {
+    const wrapper = mount(ActionMenu);
+    expect(wrapper.html()).toContain('Rename column');
+  });
+
   describe('when click on "Rename column"', () => {
-    it('should have an "Rename column" action', () => {
-      const wrapper = mount(ActionMenu);
-      const actionsWrapper = wrapper.findAll('.action-menu__option');
-
-      expect(actionsWrapper.at(1).text()).toEqual('Rename column');
-    });
-
     it('should emit an "actionClicked" event', () => {
       const wrapper = mount(ActionMenu);
       const actionsWrapper = wrapper.findAll('.action-menu__option');

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -6,7 +6,7 @@ describe('Action Menu', () => {
     const wrapper = mount(ActionMenu);
 
     expect(wrapper.exists()).toBeTruthy();
-    expect(wrapper.classes()).toContain('popover');
+    expect(wrapper.classes()).not.toContain('popover--active');
   });
 
   it('should instantiate with the popover active', () => {

--- a/tests/unit/form-rename-step.spec.ts
+++ b/tests/unit/form-rename-step.spec.ts
@@ -9,8 +9,6 @@ import { VQBState } from '@/store/state';
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
-// const emptyStore = setupStore({});
-
 interface ValidationError {
   dataPath: string;
   keyword: string;

--- a/tests/unit/form-rename-step.spec.ts
+++ b/tests/unit/form-rename-step.spec.ts
@@ -1,14 +1,15 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import FormRenameStep from '@/components/FormRenameStep.vue';
 import WidgetAutocomplete from '@/components/WidgetAutocomplete.vue';
-import Vuex from 'vuex';
+import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { Pipeline } from '@/lib/steps';
+import { VQBState } from '@/store/state';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
-const emptyStore = setupStore({});
+// const emptyStore = setupStore({});
 
 interface ValidationError {
   dataPath: string;
@@ -16,6 +17,11 @@ interface ValidationError {
 }
 
 describe('Form Rename Step', () => {
+  let emptyStore: Store<VQBState>;
+  beforeEach(() => {
+    emptyStore = setupStore({});
+  });
+
   it('should instantiate', () => {
     const wrapper = shallowMount(FormRenameStep, { store: emptyStore, localVue });
 
@@ -69,7 +75,7 @@ describe('Form Rename Step', () => {
     ]);
   });
 
-  it('should validate and emit "formSavaed" when submitted data is valid', () => {
+  it('should validate and emit "formSaved" when submitted data is valid', () => {
     const wrapper = shallowMount(FormRenameStep, {
       store: emptyStore,
       localVue,
@@ -101,7 +107,7 @@ describe('Form Rename Step', () => {
     });
     const wrapper = shallowMount(FormRenameStep, { store, localVue });
     expect(wrapper.vm.$data.step.oldname).toEqual('');
-    store.commit('toggleColumnSelection', 'columnB');
+    store.commit('toggleColumnSelection', { column: 'columnB' });
     expect(wrapper.vm.$data.step.oldname).toEqual('columnB');
   });
 


### PR DESCRIPTION
That PR create the Action Menu component that position itself according to which header we have clicked on. For the moment, only "Rename Column" is active and permit to open its form in order to create this step.

I open an issue for missing tests: #157 and that PR closes #32