### PR TITLE
[Rename step] :: error if newname corresponds to an existing column name

### DIFF
--- a/src/components/FormRenameStep.vue
+++ b/src/components/FormRenameStep.vue
@@ -38,7 +38,7 @@
 <script lang="ts">
 import _ from 'lodash';
 import { Component, Mixins, Prop, Watch } from 'vue-property-decorator';
-import FormMixin from '@/mixins/FormMixin.vue';
+import FormMixin, { VqbError } from '@/mixins/FormMixin.vue';
 import { Pipeline } from '@/lib/steps';
 import renameSchema from '@/assets/schemas/rename-step__schema.json';
 import WidgetInputText from './WidgetInputText.vue';
@@ -101,6 +101,13 @@ export default class FormRenameStep extends Mixins(FormMixin) {
     const ret = this.validator(this.step);
     if (ret === false) {
       this.errors = this.validator.errors;
+    } else if (this.columnNames.includes(this.step.newname)) {
+      const err: VqbError = {
+        keyword: 'nameAlreadyUsed',
+        dataPath: '.newname',
+        message: 'This column name is already used.',
+      };
+      this.errors = [err];
     } else {
       this.errors = null;
       this.$emit('formSaved', { name: 'rename', ...this.step });

--- a/src/mixins/FormMixin.vue
+++ b/src/mixins/FormMixin.vue
@@ -2,9 +2,12 @@
 import { Component, Vue } from 'vue-property-decorator';
 import Ajv, { ValidateFunction, ErrorObject } from 'ajv';
 
-@Component    
+type VqbError = Partial<ErrorObject>;
+
+@Component
 export default class FormMixin extends Vue {
-  errors?: ErrorObject[] | null = null;
+  // errors?: ErrorObject[] | null = null;
+  errors?: VqbError[] | null = null;
   validator: ValidateFunction = () => false;
   schema: object = {};
 

--- a/src/mixins/FormMixin.vue
+++ b/src/mixins/FormMixin.vue
@@ -6,7 +6,6 @@ type VqbError = Partial<ErrorObject>;
 
 @Component
 export default class FormMixin extends Vue {
-  // errors?: ErrorObject[] | null = null;
   errors?: VqbError[] | null = null;
   validator: ValidateFunction = () => false;
   schema: object = {};


### PR DESCRIPTION
Return an error if trying to rename a column with an already used column name.

Closes https://github.com/ToucanToco/vue-query-builder/issues/162