### PR TITLE
[circleci] run jest in a single thread

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - checkout
       - run: yarn
-      - run: yarn test:unit
+      - run: yarn test:unit --runInBand
       - run: yarn codecov
 
 workflows:


### PR DESCRIPTION
in order to avoid extreme slowness when running tests on the CI.

cf. https://discuss.circleci.com/t/yarn-tests-and-timeout/30741/2
and https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server