### PR TITLE
[storybook] fix rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+
 import alias from 'rollup-plugin-alias';
 import commonjs from 'rollup-plugin-commonjs';
 import css from 'rollup-plugin-css-only';
@@ -6,6 +9,23 @@ import replace from 'rollup-plugin-replace';
 import resolve from 'rollup-plugin-node-resolve';
 import typescript from 'rollup-plugin-typescript';
 import vue from 'rollup-plugin-vue';
+
+
+/**
+ * small helper to get package root dir since we can't
+ * rely on __dirname within the rollup bundling package
+ * (it is fixed to the entrypoint's dir name)
+ */
+function packageDir() {
+  let currentDir = __dirname;
+  while (!fs.existsSync(path.join(currentDir, 'package.json'))) {
+    currentDir = path.dirname(currentDir);
+    if (currentDir === '/') {
+      throw new Error('could not find package rootdir');
+    }
+  }
+  return currentDir;
+}
 
 export default {
   input: 'src/main.ts',
@@ -20,7 +40,7 @@ export default {
     resolve(),
     alias({
       resolve: ['.vue', '.json'],
-      '@': __dirname + '/src',
+      '@': path.join(packageDir(), '/src'),
     }),
     commonjs({ namedExports: { 'node_modules/mathjs/index.js': ['parse'] } }),
     css({ output: 'dist/vue-query-builder.css' }),


### PR DESCRIPTION
rollup bundling fixes the `__dirname` value to the entry point's dirname
rather than the actual module one. This could probably be fixed with a specific
plugin or by playing with the plugin order but I chose to implement a custom
`packageDir()` function that simply goes up in the directory hierarchy until
reaching the directory where `package.json` lies.