### PR TITLE
Feature :: UI "Delete column" step

### DIFF
--- a/src/assets/schemas/delete-column-step__schema.json
+++ b/src/assets/schemas/delete-column-step__schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Delete column step",
+  "type": "object",
+  "properties": {
+    "column": {
+      "type": "string",
+      "minLength": 1,
+      "title": "Column to delete",
+      "description": "Column to delete",
+      "attrs": {
+        "placeholder": "Enter a column"
+      }
+    }
+  },
+  "required": ["column"],
+  "additionalProperties": false
+}

--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -4,7 +4,7 @@
       <div class="action-menu__section">
         <div class="action-menu__option">Duplicate column</div>
         <div class="action-menu__option" @click="createRenameStep">Rename column</div>
-        <div class="action-menu__option">Delete column</div>
+        <div class="action-menu__option" @click="createDeleteColumnStep">Delete column</div>
         <div class="action-menu__option" @click="createFillnaStep">Fill null values</div>
       </div>
     </div>
@@ -12,8 +12,11 @@
 </template>
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
+import { Getter, Mutation, State } from 'vuex-class';
 import { POPOVER_ALIGN } from '@/components/constants';
 import Popover from './Popover.vue';
+import { Pipeline, PipelineStep } from '@/lib/steps';
+import { MutationCallbacks } from '@/store/mutations';
 
 @Component({
   name: 'action-menu',
@@ -34,6 +37,13 @@ export default class ActionMenu extends Vue {
   })
   columnName!: string;
 
+  @State pipeline!: Pipeline;
+
+  @Getter computedActiveStepIndex!: number;
+
+  @Mutation selectStep!: MutationCallbacks['selectStep'];
+  @Mutation setPipeline!: MutationCallbacks['setPipeline'];
+
   alignLeft: string = POPOVER_ALIGN.LEFT;
 
   /**
@@ -49,6 +59,16 @@ export default class ActionMenu extends Vue {
 
   close() {
     this.$emit('closed');
+  }
+
+  createDeleteColumnStep() {
+    const newPipeline: Pipeline = [...this.pipeline];
+    const index = this.computedActiveStepIndex + 1;
+    const deletecolumnStep: PipelineStep = { name: 'delete', columns: [this.columnName] };
+    newPipeline.splice(index, 0, deletecolumnStep);
+    this.setPipeline({ pipeline: newPipeline });
+    this.selectStep({ index });
+    this.close();
   }
 
   createFillnaStep() {

--- a/src/components/DeleteColumnStepForm.vue
+++ b/src/components/DeleteColumnStepForm.vue
@@ -1,0 +1,138 @@
+<template>
+  <div>
+    <div class="step-edit-form">
+      <h1 class="step-edit-form__title">DELETE COLUMN STEP</h1>
+    </div>
+    <WidgetAutocomplete
+      id="columnInput"
+      v-model="column"
+      name="Delete column:"
+      :options="columnNames"
+      @input="setSelectedColumns({ column })"
+      placeholder="Enter a column"
+    ></WidgetAutocomplete>
+    <div class="widget-form-action">
+      <button
+        class="widget-form-action__button widget-form-action__button--validate"
+        @click="validateStep"
+      >OK</button>
+      <button
+        class="widget-form-action__button widget-form-action__button--cancel"
+        @click="cancelEdition"
+      >Cancel</button>
+    </div>
+    <div v-if="errors" class="errors">
+      <ul>
+        <li v-for="(error, index) in errors" :key="index">{{ error.dataPath }}: {{ error.message }}</li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import _ from 'lodash';
+import { Mixins, Prop, Watch } from 'vue-property-decorator';
+import FormMixin from '@/mixins/FormMixin.vue';
+import { Pipeline } from '@/lib/steps';
+import deleteSchema from '@/assets/schemas/delete-column-step__schema.json';
+import WidgetAutocomplete from '@/components/WidgetAutocomplete.vue';
+import { Getter, Mutation, State } from 'vuex-class';
+import { StepFormComponent } from '@/components/formlib';
+import { MutationCallbacks } from '@/store/mutations';
+
+interface DeleteColumnStepConf {
+  columns: string[];
+}
+
+@StepFormComponent({
+  vqbstep: 'delete',
+  name: 'delete-step-form',
+  components: {
+    WidgetAutocomplete,
+  },
+})
+export default class DeletStepForm extends Mixins(FormMixin) {
+  @Prop({
+    type: Object,
+    default: () => ({
+      columns: [''],
+    }),
+  })
+  initialValue!: DeleteColumnStepConf;
+
+  @Prop({
+    type: Boolean,
+    default: true,
+  })
+  isStepCreation!: boolean;
+
+  // Only manage the deletion of 1 column at once at this stage
+  column: string = this.initialValue.columns[0];
+
+  @State pipeline!: Pipeline;
+  @State selectedStepIndex!: number;
+
+  @Mutation selectStep!: MutationCallbacks['selectStep'];
+  @Mutation setSelectedColumns!: MutationCallbacks['setSelectedColumns'];
+
+  @Getter selectedColumns!: string[];
+  @Getter columnNames!: string[];
+  @Getter computedActiveStepIndex!: number;
+
+  @Watch('selectedColumns')
+  onSelectedColumnsChanged(val: string[], oldVal: string[]) {
+    if (!_.isEqual(val, oldVal)) {
+      this.column = val[0];
+    }
+  }
+
+  created() {
+    this.schema = deleteSchema;
+    this.setSelectedColumns({ column: this.initialValue.columns[0] });
+  }
+
+  validateStep() {
+    const ret = this.validator({ column: this.column });
+    if (ret === false) {
+      this.errors = this.validator.errors;
+    } else {
+      this.errors = null;
+      this.$emit('formSaved', { name: 'delete', columns: [this.column] });
+    }
+  }
+
+  cancelEdition() {
+    this.$emit('cancel');
+    const idx = this.isStepCreation ? this.computedActiveStepIndex : this.selectedStepIndex + 1;
+    this.selectStep({ index: idx });
+  }
+}
+</script>
+<style lang="scss" scoped>
+@import '../styles/_variables';
+
+.widget-form-action__button {
+  @extend %button-default;
+}
+
+.widget-form-action__button--validate {
+  background-color: $active-color;
+}
+
+.step-edit-form {
+  border-bottom: 1px solid $grey;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding-bottom: 20px;
+  margin: 10px 0 15px;
+  width: 100%;
+}
+
+.step-edit-form__title {
+  color: $base-color;
+  font-weight: 600;
+  font-size: 14px;
+  margin: 0;
+}
+</style>

--- a/src/components/Vqb.vue
+++ b/src/components/Vqb.vue
@@ -23,6 +23,7 @@ import { Getter, Mutation, State } from 'vuex-class';
 import { VQBState } from '@/store/state';
 import { Pipeline, PipelineStep } from '@/lib/steps';
 import DataViewer from '@/components/DataViewer.vue';
+import DeleteColumnStepForm from '@/components/DeleteColumnStepForm.vue';
 import FillnaStepForm from '@/components/FillnaStepForm.vue';
 import RenameStepForm from '@/components/RenameStepForm.vue';
 import PipelineComponent from '@/components/Pipeline.vue';
@@ -34,6 +35,7 @@ import _ from 'lodash';
 @Component({
   components: {
     DataViewer,
+    DeleteColumnStepForm,
     FillnaStepForm,
     RenameStepForm,
     Pipeline: PipelineComponent,

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -36,13 +36,25 @@ type SelectedStepMutation = {
   payload: { index: number };
 };
 
+type SelectedColumnsMutation = {
+  type: 'setSelectedColumns';
+  payload: { column: string };
+};
+
+type ToggleColumnSelectionMutation = {
+  type: 'toggleColumnSelection';
+  payload: { column: string };
+};
+
 export type StateMutation =
   | DatasetMutation
   | DeleteStepMutation
   | DomainsMutation
   | PipelineMutation
+  | SelectedColumnsMutation
   | SelectDomainMutation
-  | SelectedStepMutation;
+  | SelectedStepMutation
+  | ToggleColumnSelectionMutation;
 
 type MutationByType<M, MT> = M extends { type: MT } ? M : never;
 export type MutationCallbacks = {

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
-import { mount } from '@vue/test-utils';
+import { mount, createLocalVue } from '@vue/test-utils';
 import ActionMenu from '@/components/ActionMenu.vue';
+import Vuex from 'vuex';
+import { setupStore } from '@/store';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
 
 describe('Action Menu', () => {
   it('should instantiate with its popover hidden', () => {
@@ -30,7 +35,7 @@ describe('Action Menu', () => {
     expect(wrapper.html()).to.contain('Fill null values');
   });
 
-  describe('when click on "Rename column"', () => {
+  describe('when clicking on "Rename column"', () => {
     it('should emit an "actionClicked" event with proper options', () => {
       const wrapper = mount(ActionMenu, {
         propsData: {
@@ -45,9 +50,50 @@ describe('Action Menu', () => {
         { name: 'rename', oldname: 'dreamfall', newname: '' },
       ]);
     });
+
+    it('should emit a close event', () => {
+      const wrapper = mount(ActionMenu, {
+        propsData: {
+          columnName: 'dreamfall',
+        },
+      });
+      const actionsWrapper = wrapper.findAll('.action-menu__option');
+      actionsWrapper.at(3).trigger('click');
+
+      expect(wrapper.emitted().closed).to.exist;
+    });
   });
 
-  describe('when click on "Fill null values"', () => {
+  describe('when clicking on "Delete column"', () => {
+    it('should add a valide delete step in the pipeline', async () => {
+      const store = setupStore();
+      const wrapper = mount(ActionMenu, {
+        store,
+        localVue,
+        propsData: {
+          columnName: 'columnA',
+        },
+      });
+      const actionsWrapper = wrapper.findAll('.action-menu__option');
+      actionsWrapper.at(2).trigger('click');
+      await localVue.nextTick();
+      expect(store.state.pipeline).to.eql([{ name: 'delete', columns: ['columnA'] }]);
+    });
+
+    it('should emit a close event', () => {
+      const wrapper = mount(ActionMenu, {
+        propsData: {
+          columnName: 'dreamfall',
+        },
+      });
+      const actionsWrapper = wrapper.findAll('.action-menu__option');
+      actionsWrapper.at(3).trigger('click');
+
+      expect(wrapper.emitted().closed).to.exist;
+    });
+  });
+
+  describe('when clicking on "Fill null values"', () => {
     it('should emit an "actionClicked" event with proper options', () => {
       const wrapper = mount(ActionMenu, {
         propsData: {
@@ -61,5 +107,17 @@ describe('Action Menu', () => {
         { name: 'fillna', column: 'dreamfall', value: '' },
       ]);
     });
+  });
+
+  it('should emit a close event', () => {
+    const wrapper = mount(ActionMenu, {
+      propsData: {
+        columnName: 'dreamfall',
+      },
+    });
+    const actionsWrapper = wrapper.findAll('.action-menu__option');
+    actionsWrapper.at(3).trigger('click');
+
+    expect(wrapper.emitted().closed).to.exist;
   });
 });

--- a/tests/unit/delete-column-step-form.spec.ts
+++ b/tests/unit/delete-column-step-form.spec.ts
@@ -1,0 +1,149 @@
+import { expect } from 'chai';
+import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import DeleteColumnStepForm from '@/components/DeleteColumnStepForm.vue';
+import WidgetAutocomplete from '@/components/WidgetAutocomplete.vue';
+import Vuex, { Store } from 'vuex';
+import { setupStore } from '@/store';
+import { Pipeline } from '@/lib/steps';
+import { VQBState } from '@/store/state';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+interface ValidationError {
+  dataPath: string;
+  keyword: string;
+}
+
+describe('Delete Column Step Form', () => {
+  let emptyStore: Store<VQBState>;
+  beforeEach(() => {
+    emptyStore = setupStore({});
+  });
+
+  it('should instantiate', () => {
+    const wrapper = shallowMount(DeleteColumnStepForm, { store: emptyStore, localVue });
+
+    expect(wrapper.exists()).to.be.true;
+  });
+
+  it('should have a widget autocomplete', () => {
+    const wrapper = shallowMount(DeleteColumnStepForm, { store: emptyStore, localVue });
+
+    expect(wrapper.find('widgetautocomplete-stub').exists()).to.be.true;
+  });
+
+  it('should instantiate an autocomplete widget with proper options from the store', () => {
+    const store = setupStore({
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+    });
+    const wrapper = shallowMount(DeleteColumnStepForm, { store, localVue });
+    const widgetAutocomplete = wrapper.find('widgetautocomplete-stub');
+
+    expect(widgetAutocomplete.attributes('options')).to.equal('columnA,columnB,columnC');
+  });
+
+  it('should report errors when submitted data is not valid', () => {
+    const wrapper = shallowMount(DeleteColumnStepForm, { store: emptyStore, localVue });
+    wrapper.find('.widget-form-action__button--validate').trigger('click');
+    const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
+      keyword: err.keyword,
+      dataPath: err.dataPath,
+    }));
+    expect(errors).to.eql([{ keyword: 'minLength', dataPath: '.column' }]);
+  });
+
+  it('should validate and emit "formSaved" when submitted data is valid', () => {
+    const wrapper = shallowMount(DeleteColumnStepForm, {
+      store: emptyStore,
+      localVue,
+      propsData: {
+        initialValue: { columns: ['foo'] },
+      },
+    });
+    wrapper.find('.widget-form-action__button--validate').trigger('click');
+    expect(wrapper.vm.$data.errors).to.be.null;
+    expect(wrapper.emitted()).to.eql({
+      formSaved: [[{ name: 'delete', columns: ['foo'] }]],
+    });
+  });
+
+  it('should emit "cancel" event when edition is canceled', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+    ];
+    const store = setupStore({
+      pipeline,
+      selectedStepIndex: 1,
+    });
+
+    const wrapper = shallowMount(DeleteColumnStepForm, { store, localVue });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    expect(wrapper.emitted()).to.eql({ cancel: [[]] });
+    expect(store.state.selectedStepIndex).to.equal(1);
+    expect(store.state.pipeline).to.eql([
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+    ]);
+  });
+
+  it('should update step when column is changed', async () => {
+    const store = setupStore({
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+    });
+    const wrapper = shallowMount(DeleteColumnStepForm, { store, localVue });
+    expect(wrapper.vm.$data.column).to.equal('');
+    store.commit('toggleColumnSelection', { column: 'columnB' });
+    await localVue.nextTick();
+    expect(wrapper.vm.$data.column).to.equal('columnB');
+  });
+
+  it('should update selectedColumn when column is changed', async () => {
+    const store = setupStore({
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+      selectedColumns: ['columnA'],
+    });
+    const wrapper = mount(DeleteColumnStepForm, {
+      propsData: {
+        initialValue: {
+          columns: ['columnA'],
+        },
+      },
+      store,
+      localVue,
+    });
+    wrapper.setData({ column: 'columnB' });
+    await wrapper.find(WidgetAutocomplete).trigger('input');
+    expect(store.state.selectedColumns).to.eql(['columnB']);
+  });
+
+  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+      { name: 'rename', oldname: 'baz', newname: 'spam' },
+      { name: 'rename', oldname: 'tic', newname: 'tac' },
+    ];
+    const store = setupStore({
+      pipeline,
+      selectedStepIndex: 2,
+    });
+    const wrapper = shallowMount(DeleteColumnStepForm, { store, localVue });
+    wrapper.setProps({ isStepCreation: true });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    expect(store.state.selectedStepIndex).to.equal(2);
+    wrapper.setProps({ isStepCreation: false });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    expect(store.state.selectedStepIndex).to.equal(3);
+  });
+});

--- a/tests/unit/karma-test-suite.ts
+++ b/tests/unit/karma-test-suite.ts
@@ -2,6 +2,7 @@ import './action-menu.spec';
 import './dataset.spec';
 import './data-viewer-cell.spec';
 import './data-viewer.spec';
+import './delete-column-step-form.spec';
 import './fillna-step-form.spec';
 import './formlib.spec';
 import './mongo.spec';

--- a/tests/unit/vqb.spec.ts
+++ b/tests/unit/vqb.spec.ts
@@ -28,6 +28,19 @@ describe('Vqb', () => {
     expect(form.exists()).to.be.true;
   });
 
+  it('should instantiate a DeleteColumnStep component', () => {
+    const store = setupStore({ isEditingStep: true });
+    const wrapper = shallowMount(Vqb, {
+      store,
+      localVue,
+      data: () => {
+        return { formToInstantiate: 'DeleteColumnStepForm' };
+      },
+    });
+    const form = wrapper.find('DeleteColumnStepForm-stub');
+    expect(form.exists()).to.be.true;
+  });
+
   it('should instantiate a FillnaStep component', () => {
     const store = setupStore({ isEditingStep: true });
     const wrapper = shallowMount(Vqb, {
@@ -76,7 +89,7 @@ describe('Vqb', () => {
   it('should cancel edition', async () => {
     const store = setupStore({
       pipeline: [{ name: 'domain', domain: 'foo' }],
-      isEditingStep: true
+      isEditingStep: true,
     });
     const wrapper = shallowMount(Vqb, {
       store,


### PR DESCRIPTION
We now can delete a column from the action menu available on click on a column header.
When clicking on "Delete column" it directly deletes it and create the corresponding step in the pipeline (no need to go through a form).
The step can be edited via a form asking for a change of column to be deleted.

While the step API is built to allow the deletion of several columns at once, at this stage we manage the UI to delete only 1 column at once.