### PR TITLE
[forms] move step forms in a specific directory

### DIFF
--- a/src/components/Vqb.vue
+++ b/src/components/Vqb.vue
@@ -23,11 +23,9 @@ import { Getter, Mutation, State } from 'vuex-class';
 import { VQBState } from '@/store/state';
 import { Pipeline, PipelineStep } from '@/lib/steps';
 import DataViewer from '@/components/DataViewer.vue';
-import DeleteColumnStepForm from '@/components/DeleteColumnStepForm.vue';
-import FillnaStepForm from '@/components/FillnaStepForm.vue';
-import RenameStepForm from '@/components/RenameStepForm.vue';
 import PipelineComponent from '@/components/Pipeline.vue';
 import ResizablePanels from '@/components/ResizablePanels.vue';
+import '@/components/stepforms';  // required to load all step forms
 import { STEPFORM_REGISTRY } from './formlib';
 
 import _ from 'lodash';
@@ -35,9 +33,6 @@ import _ from 'lodash';
 @Component({
   components: {
     DataViewer,
-    DeleteColumnStepForm,
-    FillnaStepForm,
-    RenameStepForm,
     Pipeline: PipelineComponent,
     ResizablePanels,
   },

--- a/src/components/formlib.ts
+++ b/src/components/formlib.ts
@@ -39,6 +39,10 @@ export function StepFormComponent(
     }
     const decorated = Component(_.omit(config, 'vqbstep'))(target);
     registry[config.vqbstep] = decorated;
+    // register component globally. This is OK, we know that this component has
+    // to be available and used at some point. Furthermore, we won't have to import
+    // manually each step form in the hosting component.
+    Vue.component(`${config.vqbstep}-step-form`, decorated);
     return decorated;
   };
 }

--- a/src/components/stepforms/DeleteColumnStepForm.vue
+++ b/src/components/stepforms/DeleteColumnStepForm.vue
@@ -1,17 +1,16 @@
 <template>
   <div>
     <div class="step-edit-form">
-      <h1 class="step-edit-form__title">FILL NULL VALUES STEP</h1>
+      <h1 class="step-edit-form__title">DELETE COLUMN STEP</h1>
     </div>
     <WidgetAutocomplete
       id="columnInput"
-      v-model="step.column"
-      name="Fill null values in:"
+      v-model="column"
+      name="Delete column:"
       :options="columnNames"
-      @input="setSelectedColumns({ column: step.column })"
+      @input="setSelectedColumns({ column })"
       placeholder="Enter a column"
     ></WidgetAutocomplete>
-    <WidgetInputText id="valueInput" v-model="step.value" name="With:" placeholder="Enter a value"></WidgetInputText>
     <div class="widget-form-action">
       <button
         class="widget-form-action__button widget-form-action__button--validate"
@@ -35,34 +34,31 @@ import _ from 'lodash';
 import { Mixins, Prop, Watch } from 'vue-property-decorator';
 import FormMixin from '@/mixins/FormMixin.vue';
 import { Pipeline } from '@/lib/steps';
-import fillnaSchema from '@/assets/schemas/fillna-step__schema.json';
-import WidgetInputText from './WidgetInputText.vue';
-import WidgetAutocomplete from '@/components/WidgetAutocomplete.vue';
+import deleteSchema from '@/assets/schemas/delete-column-step__schema.json';
+import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
 import { Getter, Mutation, State } from 'vuex-class';
 import { StepFormComponent } from '@/components/formlib';
+import { MutationCallbacks } from '@/store/mutations';
 
-interface FillnaStepConf {
-  column: string;
-  value: string;
+interface DeleteColumnStepConf {
+  columns: string[];
 }
 
 @StepFormComponent({
-  vqbstep: 'fillna',
-  name: 'fillna-step-form',
+  vqbstep: 'delete',
+  name: 'delete-step-form',
   components: {
     WidgetAutocomplete,
-    WidgetInputText,
   },
 })
-export default class FillnaStepForm extends Mixins(FormMixin) {
+export default class DeletStepForm extends Mixins(FormMixin) {
   @Prop({
     type: Object,
     default: () => ({
-      column: '',
-      value: '',
+      columns: [''],
     }),
   })
-  initialValue!: FillnaStepConf;
+  initialValue!: DeleteColumnStepConf;
 
   @Prop({
     type: Boolean,
@@ -70,13 +66,14 @@ export default class FillnaStepForm extends Mixins(FormMixin) {
   })
   isStepCreation!: boolean;
 
-  step: FillnaStepConf = { ...this.initialValue };
+  // Only manage the deletion of 1 column at once at this stage
+  column: string = this.initialValue.columns[0];
 
   @State pipeline!: Pipeline;
   @State selectedStepIndex!: number;
 
-  @Mutation selectStep!: (payload: { index: number }) => void;
-  @Mutation setSelectedColumns!: (payload: { column: string }) => void;
+  @Mutation selectStep!: MutationCallbacks['selectStep'];
+  @Mutation setSelectedColumns!: MutationCallbacks['setSelectedColumns'];
 
   @Getter selectedColumns!: string[];
   @Getter columnNames!: string[];
@@ -85,22 +82,22 @@ export default class FillnaStepForm extends Mixins(FormMixin) {
   @Watch('selectedColumns')
   onSelectedColumnsChanged(val: string[], oldVal: string[]) {
     if (!_.isEqual(val, oldVal)) {
-      this.step.column = val[0];
+      this.column = val[0];
     }
   }
 
   created() {
-    this.schema = fillnaSchema;
-    this.setSelectedColumns({ column: this.initialValue.column });
+    this.schema = deleteSchema;
+    this.setSelectedColumns({ column: this.initialValue.columns[0] });
   }
 
   validateStep() {
-    const ret = this.validator(this.step);
+    const ret = this.validator({ column: this.column });
     if (ret === false) {
       this.errors = this.validator.errors;
     } else {
       this.errors = null;
-      this.$emit('formSaved', { name: 'fillna', ...this.step });
+      this.$emit('formSaved', { name: 'delete', columns: [this.column] });
     }
   }
 
@@ -112,7 +109,7 @@ export default class FillnaStepForm extends Mixins(FormMixin) {
 }
 </script>
 <style lang="scss" scoped>
-@import '../styles/_variables';
+@import '../../styles/_variables';
 
 .widget-form-action__button {
   @extend %button-default;

--- a/src/components/stepforms/FillnaStepForm.vue
+++ b/src/components/stepforms/FillnaStepForm.vue
@@ -1,16 +1,17 @@
 <template>
   <div>
     <div class="step-edit-form">
-      <h1 class="step-edit-form__title">DELETE COLUMN STEP</h1>
+      <h1 class="step-edit-form__title">FILL NULL VALUES STEP</h1>
     </div>
     <WidgetAutocomplete
       id="columnInput"
-      v-model="column"
-      name="Delete column:"
+      v-model="step.column"
+      name="Fill null values in:"
       :options="columnNames"
-      @input="setSelectedColumns({ column })"
+      @input="setSelectedColumns({ column: step.column })"
       placeholder="Enter a column"
     ></WidgetAutocomplete>
+    <WidgetInputText id="valueInput" v-model="step.value" name="With:" placeholder="Enter a value"></WidgetInputText>
     <div class="widget-form-action">
       <button
         class="widget-form-action__button widget-form-action__button--validate"
@@ -34,31 +35,34 @@ import _ from 'lodash';
 import { Mixins, Prop, Watch } from 'vue-property-decorator';
 import FormMixin from '@/mixins/FormMixin.vue';
 import { Pipeline } from '@/lib/steps';
-import deleteSchema from '@/assets/schemas/delete-column-step__schema.json';
-import WidgetAutocomplete from '@/components/WidgetAutocomplete.vue';
+import fillnaSchema from '@/assets/schemas/fillna-step__schema.json';
+import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
+import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
 import { Getter, Mutation, State } from 'vuex-class';
 import { StepFormComponent } from '@/components/formlib';
-import { MutationCallbacks } from '@/store/mutations';
 
-interface DeleteColumnStepConf {
-  columns: string[];
+interface FillnaStepConf {
+  column: string;
+  value: string;
 }
 
 @StepFormComponent({
-  vqbstep: 'delete',
-  name: 'delete-step-form',
+  vqbstep: 'fillna',
+  name: 'fillna-step-form',
   components: {
     WidgetAutocomplete,
+    WidgetInputText,
   },
 })
-export default class DeletStepForm extends Mixins(FormMixin) {
+export default class FillnaStepForm extends Mixins(FormMixin) {
   @Prop({
     type: Object,
     default: () => ({
-      columns: [''],
+      column: '',
+      value: '',
     }),
   })
-  initialValue!: DeleteColumnStepConf;
+  initialValue!: FillnaStepConf;
 
   @Prop({
     type: Boolean,
@@ -66,14 +70,13 @@ export default class DeletStepForm extends Mixins(FormMixin) {
   })
   isStepCreation!: boolean;
 
-  // Only manage the deletion of 1 column at once at this stage
-  column: string = this.initialValue.columns[0];
+  step: FillnaStepConf = { ...this.initialValue };
 
   @State pipeline!: Pipeline;
   @State selectedStepIndex!: number;
 
-  @Mutation selectStep!: MutationCallbacks['selectStep'];
-  @Mutation setSelectedColumns!: MutationCallbacks['setSelectedColumns'];
+  @Mutation selectStep!: (payload: { index: number }) => void;
+  @Mutation setSelectedColumns!: (payload: { column: string }) => void;
 
   @Getter selectedColumns!: string[];
   @Getter columnNames!: string[];
@@ -82,22 +85,22 @@ export default class DeletStepForm extends Mixins(FormMixin) {
   @Watch('selectedColumns')
   onSelectedColumnsChanged(val: string[], oldVal: string[]) {
     if (!_.isEqual(val, oldVal)) {
-      this.column = val[0];
+      this.step.column = val[0];
     }
   }
 
   created() {
-    this.schema = deleteSchema;
-    this.setSelectedColumns({ column: this.initialValue.columns[0] });
+    this.schema = fillnaSchema;
+    this.setSelectedColumns({ column: this.initialValue.column });
   }
 
   validateStep() {
-    const ret = this.validator({ column: this.column });
+    const ret = this.validator(this.step);
     if (ret === false) {
       this.errors = this.validator.errors;
     } else {
       this.errors = null;
-      this.$emit('formSaved', { name: 'delete', columns: [this.column] });
+      this.$emit('formSaved', { name: 'fillna', ...this.step });
     }
   }
 
@@ -109,7 +112,7 @@ export default class DeletStepForm extends Mixins(FormMixin) {
 }
 </script>
 <style lang="scss" scoped>
-@import '../styles/_variables';
+@import '../../styles/_variables';
 
 .widget-form-action__button {
   @extend %button-default;

--- a/src/components/stepforms/RenameStepForm.vue
+++ b/src/components/stepforms/RenameStepForm.vue
@@ -41,8 +41,8 @@ import { Mixins, Prop, Watch } from 'vue-property-decorator';
 import FormMixin from '@/mixins/FormMixin.vue';
 import { Pipeline } from '@/lib/steps';
 import renameSchema from '@/assets/schemas/rename-step__schema.json';
-import WidgetInputText from './WidgetInputText.vue';
-import WidgetAutocomplete from '@/components/WidgetAutocomplete.vue';
+import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
+import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
 import { Getter, Mutation, State } from 'vuex-class';
 import { StepFormComponent } from '@/components/formlib';
 
@@ -125,7 +125,7 @@ export default class RenameStepForm extends Mixins(FormMixin) {
 }
 </script>
 <style lang="scss" scoped>
-@import '../styles/_variables';
+@import '../../styles/_variables';
 
 .widget-form-action__button {
   @extend %button-default;

--- a/src/components/stepforms/WidgetAutocomplete.vue
+++ b/src/components/stepforms/WidgetAutocomplete.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="widget-autocomplete__container">
     <label class="widget-autocomplete__label" :for="id">{{ name }}</label>
-    <multiselect v-model="editedValue" :options="options" :placeholder="placeholder" :allow-empty="false"></multiselect>
+    <multiselect
+      v-model="editedValue"
+      :options="options"
+      :placeholder="placeholder"
+      :allow-empty="false"
+    ></multiselect>
   </div>
 </template>
 
@@ -47,7 +52,7 @@ export default class WidgetAutocomplete extends Vue {
 
 <style src="vue-multiselect/dist/vue-multiselect.min.css"></style>
 <style lang="scss">
-@import '../styles/_variables';
+@import '../../styles/_variables';
 
 .widget-autocomplete__container {
   @extend %form-widget__container;

--- a/src/components/stepforms/WidgetInputText.vue
+++ b/src/components/stepforms/WidgetInputText.vue
@@ -56,7 +56,7 @@ export default class WidgetInputText extends Vue {
 </script>
 
 <style lang="scss" scoped>
-@import '../styles/_variables';
+@import '../../styles/_variables';
 
 .widget-input-text__container {
   @extend %form-widget__container;
@@ -73,5 +73,4 @@ export default class WidgetInputText extends Vue {
 .widget-input-text__container label {
   @extend %form-widget__label;
 }
-
 </style>

--- a/src/components/stepforms/index.ts
+++ b/src/components/stepforms/index.ts
@@ -1,0 +1,3 @@
+import './DeleteColumnStepForm.vue';
+import './FillnaStepForm.vue';
+import './RenameStepForm.vue';

--- a/tests/unit/delete-column-step-form.spec.ts
+++ b/tests/unit/delete-column-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import DeleteColumnStepForm from '@/components/DeleteColumnStepForm.vue';
-import WidgetAutocomplete from '@/components/WidgetAutocomplete.vue';
+import DeleteColumnStepForm from '@/components/stepforms/DeleteColumnStepForm.vue';
+import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
 import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { Pipeline } from '@/lib/steps';

--- a/tests/unit/fillna-step-form.spec.ts
+++ b/tests/unit/fillna-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import FillnaStepForm from '@/components/FillnaStepForm.vue';
-import WidgetAutocomplete from '@/components/WidgetAutocomplete.vue';
+import FillnaStepForm from '@/components/stepforms/FillnaStepForm.vue';
+import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
 import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { Pipeline } from '@/lib/steps';
@@ -163,7 +163,7 @@ describe('Fillna Step Form', () => {
         },
       },
       store,
-      localVue
+      localVue,
     });
     wrapper.find('.widget-form-action__button--validate').trigger('click');
     await localVue.nextTick();

--- a/tests/unit/rename-step-form.spec.ts
+++ b/tests/unit/rename-step-form.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vue from 'vue';
-import RenameStepForm from '@/components/RenameStepForm.vue';
-import WidgetAutocomplete from '@/components/WidgetAutocomplete.vue';
+import RenameStepForm from '@/components/stepforms/RenameStepForm.vue';
+import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
 import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { Pipeline } from '@/lib/steps';

--- a/tests/unit/vqb.spec.ts
+++ b/tests/unit/vqb.spec.ts
@@ -21,10 +21,10 @@ describe('Vqb', () => {
       store,
       localVue,
       data: () => {
-        return { formToInstantiate: 'RenameStepForm' };
+        return { formToInstantiate: 'rename-step-form' };
       },
     });
-    const form = wrapper.find('renamestepform-stub');
+    const form = wrapper.find('rename-step-form-stub');
     expect(form.exists()).to.be.true;
   });
 
@@ -34,10 +34,10 @@ describe('Vqb', () => {
       store,
       localVue,
       data: () => {
-        return { formToInstantiate: 'DeleteColumnStepForm' };
+        return { formToInstantiate: 'delete-step-form' };
       },
     });
-    const form = wrapper.find('DeleteColumnStepForm-stub');
+    const form = wrapper.find('delete-step-form-stub');
     expect(form.exists()).to.be.true;
   });
 
@@ -47,10 +47,10 @@ describe('Vqb', () => {
       store,
       localVue,
       data: () => {
-        return { formToInstantiate: 'FillnaStepForm' };
+        return { formToInstantiate: 'fillna-step-form' };
       },
     });
-    const form = wrapper.find('fillnastepform-stub');
+    const form = wrapper.find('fillna-step-form-stub');
     expect(form.exists()).to.be.true;
   });
 
@@ -73,12 +73,12 @@ describe('Vqb', () => {
       store,
       localVue,
       data: () => {
-        return { formToInstantiate: 'RenameStepForm' };
+        return { formToInstantiate: 'rename-step-form' };
       },
     });
     await Vue.nextTick();
     wrapper
-      .find('renamestepform-stub')
+      .find('rename-step-form-stub')
       .vm.$emit('formSaved', { name: 'rename', oldname: 'columnA', newname: 'columnAA' });
     expect(store.state.isEditingStep).to.be.false;
     expect(store.state.pipeline).to.eql([
@@ -95,11 +95,11 @@ describe('Vqb', () => {
       store,
       localVue,
       data: () => {
-        return { formToInstantiate: 'RenameStepForm' };
+        return { formToInstantiate: 'rename-step-form' };
       },
     });
     await Vue.nextTick();
-    wrapper.find('renamestepform-stub').vm.$emit('cancel');
+    wrapper.find('rename-step-form-stub').vm.$emit('cancel');
     expect(store.state.isEditingStep).to.be.false;
     expect(store.state.pipeline).to.eql([{ name: 'domain', domain: 'foo' }]);
   });

--- a/tests/unit/widget-autocomplete.spec.ts
+++ b/tests/unit/widget-autocomplete.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { shallowMount } from '@vue/test-utils';
-import WidgetAutocomplete from '@/components/WidgetAutocomplete.vue';
+import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
 
 describe('Widget Autocomplete', () => {
   it('should instantiate', () => {

--- a/tests/unit/widget-input-text.spec.ts
+++ b/tests/unit/widget-input-text.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { shallowMount } from '@vue/test-utils';
 import Vue from 'vue';
-import WidgetInputText from '@/components/WidgetInputText.vue';
+import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
 
 describe('Widget Input Text', () => {
   it('should instantiate', () => {


### PR DESCRIPTION
The directory is `src/components/stepforms` and its `index.ts` must
import all form components so that they registered automatically in the
`STEPFORM_REGISTRY`.

Note that we therefore still have to import `stepforms/` manually once at
some point.