### PR TITLE
[karma] fix injection slots in context.html

### DIFF
--- a/tests/context.html
+++ b/tests/context.html
@@ -27,11 +27,11 @@ Reloaded before every execution run.
     <script src="context.js"></script>
     <script type="text/javascript">
       // Configure our Karma and set up bindings
-      % CLIENT_CONFIG %
+      %CLIENT_CONFIG%
         window.__karma__.setupContext(window);
 
       // All served files with the latest timestamps
-      % MAPPINGS %
+      %MAPPINGS%
     </script>
     <!-- Dynamically replaced with <script> tags -->
     %SCRIPTS%


### PR DESCRIPTION
Injection slots are supposed to be `%CLIENT_CONFIG%` and `%MAPPINGS%`,
not `% CLIENT_CONFIG %` and `% MAPPINGS %` otherwise substitution is not
done correclty.

This fixes:

- the syntax error message in chrome console on `%`
- the catpured logs that didn't show in the console: \o/