### PR TITLE
Feature :: Avoid bad toggling of step edition mode

### DIFF
--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -38,11 +38,13 @@ export default class ActionMenu extends Vue {
   columnName!: string;
 
   @State pipeline!: Pipeline;
+  @State isEditingStep!: boolean;
 
   @Getter computedActiveStepIndex!: number;
 
   @Mutation selectStep!: MutationCallbacks['selectStep'];
   @Mutation setPipeline!: MutationCallbacks['setPipeline'];
+  @Mutation toggleStepEdition!: () => void;
 
   alignLeft: string = POPOVER_ALIGN.LEFT;
 
@@ -66,6 +68,13 @@ export default class ActionMenu extends Vue {
     const newPipeline: Pipeline = [...this.pipeline];
     const index = this.computedActiveStepIndex + 1;
     const deletecolumnStep: PipelineStep = { name: 'delete', columns: [this.columnName] };
+    /**
+     * If a step edition form is already open, close it so that the left panel displays
+     * the pipeline with the new delete step inserted
+     */
+    if (this.isEditingStep) {
+      this.toggleStepEdition();
+    }
     newPipeline.splice(index, 0, deletecolumnStep);
     this.setPipeline({ pipeline: newPipeline });
     this.selectStep({ index });

--- a/src/components/Vqb.vue
+++ b/src/components/Vqb.vue
@@ -60,12 +60,16 @@ export default class Vqb extends Vue {
   }
 
   openStepForm(params: PipelineStep, index: number) {
-    // after that, we delete from params to pass down the others keys to initialValue
+    // If another step edition form is already open, first close it
+    if (this.isEditingStep) {
+      this.toggleStepEdition();
+    }
     this.formToInstantiate = STEPFORM_REGISTRY[params.name];
     if (this.formToInstantiate === undefined) {
       console.error('No corresponding form for this step');
       return;
     }
+    // after that, we delete from params to pass down the others keys to initialValue
     this.initialValue = _.omit(params, 'name');
     if (index !== undefined) {
       this.editedStepIndex = index;
@@ -73,6 +77,7 @@ export default class Vqb extends Vue {
     } else {
       this.editedStepIndex = -1;
     }
+    // Display step edition form in the left panel
     this.toggleStepEdition();
   }
 

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { mount, createLocalVue } from '@vue/test-utils';
+import { mount, createLocalVue, shallowMount } from '@vue/test-utils';
 import ActionMenu from '@/components/ActionMenu.vue';
 import Vuex from 'vuex';
 import { setupStore } from '@/store';
@@ -26,18 +26,18 @@ describe('Action Menu', () => {
   });
 
   it('should have an "Rename column" action', () => {
-    const wrapper = mount(ActionMenu);
+    const wrapper = shallowMount(ActionMenu);
     expect(wrapper.html()).to.contain('Rename column');
   });
 
   it('should have an "Fill null values" action', () => {
-    const wrapper = mount(ActionMenu);
+    const wrapper = shallowMount(ActionMenu);
     expect(wrapper.html()).to.contain('Fill null values');
   });
 
   describe('when clicking on "Rename column"', () => {
     it('should emit an "actionClicked" event with proper options', () => {
-      const wrapper = mount(ActionMenu, {
+      const wrapper = shallowMount(ActionMenu, {
         propsData: {
           columnName: 'dreamfall',
         },
@@ -52,13 +52,9 @@ describe('Action Menu', () => {
     });
 
     it('should emit a close event', () => {
-      const wrapper = mount(ActionMenu, {
-        propsData: {
-          columnName: 'dreamfall',
-        },
-      });
+      const wrapper = shallowMount(ActionMenu);
       const actionsWrapper = wrapper.findAll('.action-menu__option');
-      actionsWrapper.at(3).trigger('click');
+      actionsWrapper.at(1).trigger('click');
 
       expect(wrapper.emitted().closed).to.exist;
     });
@@ -67,7 +63,7 @@ describe('Action Menu', () => {
   describe('when clicking on "Delete column"', () => {
     it('should add a valide delete step in the pipeline', async () => {
       const store = setupStore();
-      const wrapper = mount(ActionMenu, {
+      const wrapper = shallowMount(ActionMenu, {
         store,
         localVue,
         propsData: {
@@ -81,21 +77,26 @@ describe('Action Menu', () => {
     });
 
     it('should emit a close event', () => {
-      const wrapper = mount(ActionMenu, {
-        propsData: {
-          columnName: 'dreamfall',
-        },
-      });
+      const store = setupStore();
+      const wrapper = shallowMount(ActionMenu, { store, localVue });
       const actionsWrapper = wrapper.findAll('.action-menu__option');
-      actionsWrapper.at(3).trigger('click');
+      actionsWrapper.at(2).trigger('click');
 
       expect(wrapper.emitted().closed).to.exist;
+    });
+
+    it('should close any open step form to show the addition of the delete step in the pipeline', () => {
+      const store = setupStore({ isEditingStep: true });
+      const wrapper = shallowMount(ActionMenu, { store, localVue });
+      const actionsWrapper = wrapper.findAll('.action-menu__option');
+      actionsWrapper.at(2).trigger('click');
+      expect(store.state.isEditingStep).to.be.false;
     });
   });
 
   describe('when clicking on "Fill null values"', () => {
     it('should emit an "actionClicked" event with proper options', () => {
-      const wrapper = mount(ActionMenu, {
+      const wrapper = shallowMount(ActionMenu, {
         propsData: {
           columnName: 'dreamfall',
         },
@@ -110,11 +111,7 @@ describe('Action Menu', () => {
   });
 
   it('should emit a close event', () => {
-    const wrapper = mount(ActionMenu, {
-      propsData: {
-        columnName: 'dreamfall',
-      },
-    });
+    const wrapper = shallowMount(ActionMenu);
     const actionsWrapper = wrapper.findAll('.action-menu__option');
     actionsWrapper.at(3).trigger('click');
 

--- a/tests/unit/vqb.spec.ts
+++ b/tests/unit/vqb.spec.ts
@@ -65,6 +65,16 @@ describe('Vqb', () => {
     expect(store.state.isEditingStep).to.be.true;
   });
 
+  it('should keep editingMode on when trying to creating a step while a form is already open', async () => {
+    const store = setupStore({ isEditingStep: true });
+    const wrapper = shallowMount(Vqb, { store, localVue });
+    wrapper
+      .find('dataviewer-stub')
+      .vm.$emit('stepCreated', { name: 'rename', oldname: 'foo', newname: 'bar' });
+    await wrapper.vm.$nextTick();
+    expect(store.state.isEditingStep).to.be.true;
+  });
+
   it('should set pipeline when form is saved', async () => {
     const store = setupStore({
       isEditingStep: true,


### PR DESCRIPTION
When a step edition form is already open and that we click on another operation, we want to keep the edition mode open, with the new form instantiated.

Before this PR, there was a trivial toggle of the edition mode which was based on the hypothesis that the edition mode was off before clicking on any operation, which is not reasonable. When the edition mode was already on it led us to click twice before opening the correct form: the first time to close the existing form, the second one to open the new form. Bad experience that is now improved !