### PR TITLE
[steps] make step type definitons writable

### DIFF
--- a/src/lib/matcher.ts
+++ b/src/lib/matcher.ts
@@ -32,8 +32,10 @@ export type StepByType<A, T> = A extends { name: T } ? A : never;
  * This type will help to enforce that each kind of step has a corresponding
  * translation function at compile time.
  */
-export type StepMatcher<T> = { [K in PipelineStepName]: (step: StepByType<PipelineStep, K>) => T };
-export type TransformStep = (step: PipelineStep) => void;
+export type StepMatcher<T> = {
+  [K in PipelineStepName]: (step: Readonly<StepByType<PipelineStep, K>>) => T
+};
+export type TransformStep = (step: Readonly<PipelineStep>) => void;
 
 /**
  * OutputStep is a base type for all step transformer functions. Since

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -4,124 +4,124 @@
 
 type PrimitiveType = number | boolean | string | Date;
 
-type AggFunctionStep = Readonly<{
+type AggFunctionStep = {
   /** Name of the output column */
   newcolumn: string;
   /** the aggregation operation (e.g. `sum` or `count`) */
   aggfunction: 'sum' | 'avg' | 'count' | 'min' | 'max';
   /** the column the aggregation function is working on */
   column: string;
-}>;
+};
 
-export type AggregationStep = Readonly<{
+export type AggregationStep = {
   name: 'aggregate';
   /** the list columns we want to aggregate on */
   on: string[];
   /** the list of aggregation operations to perform */
   aggregations: AggFunctionStep[];
-}>;
+};
 
-export type ArgmaxStep = Readonly<{
+export type ArgmaxStep = {
   name: 'argmax';
   column: string; // column in which to search for max value
   groups?: string[]; // if specified, will search for a max in every group
-}>;
+};
 
-export type ArgminStep = Readonly<{
+export type ArgminStep = {
   name: 'argmin';
   column: string; // column in which to search for max value
   groups?: string[]; // if specified, will search for a max in every group
-}>;
+};
 
-export type CustomStep = Readonly<{
+export type CustomStep = {
   name: 'custom';
   query: object;
-}>;
+};
 
-export type DeleteStep = Readonly<{
+export type DeleteStep = {
   name: 'delete';
   columns: string[];
-}>;
+};
 
-export type DomainStep = Readonly<{
+export type DomainStep = {
   name: 'domain';
   domain: string;
-}>;
+};
 
-export type FillnaStep = Readonly<{
+export type FillnaStep = {
   name: 'fillna';
   column: string;
   value: PrimitiveType;
-}>;
+};
 
-export type FilterStep = Readonly<{
+export type FilterStep = {
   name: 'filter';
   column: string;
   value: any;
   operator?: 'eq' | 'ne' | 'gt' | 'ge' | 'lt' | 'le' | 'in' | 'nin';
-}>;
+};
 
-export type FormulaStep = Readonly<{
+export type FormulaStep = {
   name: 'formula';
   new_column: string;
   formula: string;
-}>;
+};
 
-export type PercentageStep = Readonly<{
+export type PercentageStep = {
   name: 'percentage';
   new_column?: string;
   column: string;
   group?: string[];
-}>;
+};
 
-export type PivotStep = Readonly<{
+export type PivotStep = {
   name: 'pivot';
   index: string[];
   column_to_pivot: string;
   value_column: string;
   agg_function: 'sum' | 'avg' | 'count' | 'min' | 'max';
-}>;
+};
 
-export type RenameStep = Readonly<{
+export type RenameStep = {
   name: 'rename';
   oldname: string;
   newname: string;
-}>;
+};
 
-export type ReplaceStep = Readonly<{
+export type ReplaceStep = {
   name: 'replace';
   search_column: string;
   new_column?: string;
   to_replace: any[][];
-}>;
+};
 
-export type SelectStep = Readonly<{
+export type SelectStep = {
   name: 'select';
   columns: string[];
-}>;
+};
 
-export type SortStep = Readonly<{
+export type SortStep = {
   name: 'sort';
   columns: string[];
   order?: ('asc' | 'desc')[];
-}>;
+};
 
-export type TopStep = Readonly<{
+export type TopStep = {
   name: 'top';
   groups?: string[];
   rank_on: string;
   sort: 'asc' | 'desc';
   limit: number;
-}>;
+};
 
-export type UnpivotStep = Readonly<{
+export type UnpivotStep = {
   name: 'unpivot';
   keep: string[];
   unpivot: string[];
   unpivot_column_name: string;
   value_column_name: string;
   dropna: boolean;
-}>;
+};
 
 export type PipelineStep =
   | AggregationStep

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -34,7 +34,7 @@ export class StepNotSupported extends Error {
  * @param descriptor the method descriptor
  */
 function unsupported(target: BaseTranslator, propertyKey: S.PipelineStepName, descriptor: any) {
-  descriptor.value = function(step: S.PipelineStep) {
+  descriptor.value = function(step: Readonly<S.PipelineStep>) {
     throw new StepNotSupported(step.name);
   };
   descriptor.value.__vqb_step_supported__ = false;
@@ -91,55 +91,55 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
 
   /* eslint-disable no-unused-vars, @typescript-eslint/no-unused-vars */
   @unsupported
-  aggregate(step: S.AggregationStep) {}
+  aggregate(step: Readonly<S.AggregationStep>) {}
 
   @unsupported
-  argmax(step: S.ArgmaxStep) {}
+  argmax(step: Readonly<S.ArgmaxStep>) {}
 
   @unsupported
-  argmin(step: S.ArgminStep) {}
+  argmin(step: Readonly<S.ArgminStep>) {}
 
   @unsupported
-  custom(step: S.CustomStep) {}
+  custom(step: Readonly<S.CustomStep>) {}
 
   @unsupported
-  domain(step: S.DomainStep) {}
+  domain(step: Readonly<S.DomainStep>) {}
 
   @unsupported
-  delete(step: S.DeleteStep) {}
+  delete(step: Readonly<S.DeleteStep>) {}
 
   @unsupported
-  fillna(step: S.FillnaStep) {}
+  fillna(step: Readonly<S.FillnaStep>) {}
 
   @unsupported
-  filter(step: S.FilterStep) {}
+  filter(step: Readonly<S.FilterStep>) {}
 
   @unsupported
-  formula(step: S.FormulaStep) {}
+  formula(step: Readonly<S.FormulaStep>) {}
 
   @unsupported
-  percentage(step: S.PercentageStep) {}
+  percentage(step: Readonly<S.PercentageStep>) {}
 
   @unsupported
-  pivot(step: S.PivotStep) {}
+  pivot(step: Readonly<S.PivotStep>) {}
 
   @unsupported
-  rename(step: S.RenameStep) {}
+  rename(step: Readonly<S.RenameStep>) {}
 
   @unsupported
-  replace(step: S.ReplaceStep) {}
+  replace(step: Readonly<S.ReplaceStep>) {}
 
   @unsupported
-  select(step: S.SelectStep) {}
+  select(step: Readonly<S.SelectStep>) {}
 
   @unsupported
-  sort(step: S.SortStep) {}
+  sort(step: Readonly<S.SortStep>) {}
 
   @unsupported
-  top(step: S.TopStep) {}
+  top(step: Readonly<S.TopStep>) {}
 
   @unsupported
-  unpivot(step: S.UnpivotStep) {}
+  unpivot(step: Readonly<S.UnpivotStep>) {}
 
   /* eslint-enable no-unused-vars, @typescript-eslint/no-unused-vars */
 
@@ -157,7 +157,7 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
       // otherwise it will complain about
       // `((x: DomainStep) => void)) | ((x: FilterStep) => void) | ((x: ...) => void)`
       // not being assignable to `((x: DomainStep | FilterStep | ...) => void)`
-      const callback = <TransformStep>this[step.name];
+      const callback = this[step.name] as TransformStep;
       result.push(callback(step));
     }
     return result;

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -49,7 +49,7 @@ function columnMap(colnames: string[]) {
   return _.fromPairs(colnames.map(col => [col, $$(col)]));
 }
 
-function filterstepToMatchstep(step: FilterStep): MongoStep {
+function filterstepToMatchstep(step: Readonly<FilterStep>): MongoStep {
   const operatorMapping = {
     eq: '$eq',
     ne: '$ne',
@@ -65,7 +65,7 @@ function filterstepToMatchstep(step: FilterStep): MongoStep {
 }
 
 /** transform an 'aggregate' step into corresponding mongo steps */
-function transformAggregate(step: AggregationStep): MongoStep[] {
+function transformAggregate(step: Readonly<AggregationStep>): MongoStep[] {
   const idblock: PropMap<string> = columnMap(step.on);
   const group: { [id: string]: {} } = {};
   const project: PropMap<any> = {};
@@ -96,7 +96,7 @@ function transformAggregate(step: AggregationStep): MongoStep[] {
 }
 
 /** transform an 'argmax' or 'argmin' step into corresponding mongo steps */
-function transformArgmaxArgmin(step: ArgmaxStep | ArgminStep): MongoStep[] {
+function transformArgmaxArgmin(step: Readonly<ArgmaxStep> | Readonly<ArgminStep>): MongoStep[] {
   const groupMongo: MongoStep = {};
   const stepMapping = { argmax: '$max', argmin: '$min' };
 
@@ -132,7 +132,7 @@ function transformArgmaxArgmin(step: ArgmaxStep | ArgminStep): MongoStep[] {
 }
 
 /** transform an 'percentage' step into corresponding mongo steps */
-function transformPercentage(step: PercentageStep): MongoStep[] {
+function transformPercentage(step: Readonly<PercentageStep>): MongoStep[] {
   const newCol = step.new_column || step.column;
 
   return [
@@ -163,7 +163,7 @@ function transformPercentage(step: PercentageStep): MongoStep[] {
 }
 
 /** transform an 'pivot' step into corresponding mongo steps */
-function transformPivot(step: PivotStep): MongoStep[] {
+function transformPivot(step: Readonly<PivotStep>): MongoStep[] {
   const groupCols2: PropMap<string> = {};
   const addFieldsStep: PropMap<string> = {};
 
@@ -230,7 +230,7 @@ function transformPivot(step: PivotStep): MongoStep[] {
 }
 
 /** transform an 'replace' step into corresponding mongo steps */
-function transformReplace(step: ReplaceStep): MongoStep {
+function transformReplace(step: Readonly<ReplaceStep>): MongoStep {
   const branches: MongoStep[] = step.to_replace.map(([oldval, newval]) => ({
     case: { $eq: [$$(step.search_column), oldval] },
     then: newval,
@@ -245,7 +245,7 @@ function transformReplace(step: ReplaceStep): MongoStep {
 }
 
 /** transform a 'sort' step into corresponding mongo steps */
-function transformSort(step: SortStep): MongoStep {
+function transformSort(step: Readonly<SortStep>): MongoStep {
   const sortMongo: PropMap<number> = {};
   const sortOrders = step.order === undefined ? Array(step.columns.length).fill('asc') : step.order;
   for (let i = 0; i < step.columns.length; i++) {
@@ -256,7 +256,7 @@ function transformSort(step: SortStep): MongoStep {
 }
 
 /** transform an 'top' step into corresponding mongo steps */
-function transformTop(step: TopStep): MongoStep[] {
+function transformTop(step: Readonly<TopStep>): MongoStep[] {
   const sortOrder = step.sort === 'asc' ? 1 : -1;
   const groupCols = step.groups ? columnMap(step.groups) : null;
 
@@ -270,7 +270,7 @@ function transformTop(step: TopStep): MongoStep[] {
 }
 
 /** transform an 'unpivot' step into corresponding mongo steps */
-function transformUnpivot(step: UnpivotStep): MongoStep[] {
+function transformUnpivot(step: Readonly<UnpivotStep>): MongoStep[] {
   // projectCols to be included in Mongo $project steps
   const projectCols: PropMap<string> = _.fromPairs(step.keep.map(col => [col, `$${col}`]));
   // objectToArray to be included in the first Mongo $project step


### PR DESCRIPTION
Step type definitions have no good reason to be readonly. In fact,
it is actually a pain to have steps being readonly in step forms since
we can't use the step types directly on a data attribute without wrapping
them with a specific `Writable` type that removes the `readonly` modiifier.

What we actually want is to make steps readonly during the translation process,
so just declare transform step function parameters as such and everything is
fine.