### PR TITLE
[translator] fix handling of empty mongo pipelines

### DIFF
--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -349,6 +349,9 @@ function buildMongoFormulaTree(node: MathNode): MongoStep | string | number {
  * @returns the list of simplified mongo steps
  */
 export function _simplifyMongoPipeline(mongoSteps: MongoStep[]): MongoStep[] {
+  if (!mongoSteps.length) {
+    return [];
+  }
   let merge = true;
   const outputSteps: MongoStep[] = [];
   let lastStep: MongoStep = mongoSteps[0];

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -263,6 +263,11 @@ describe('Pipeline to mongo translator', () => {
     ]);
   });
 
+  it('can simplify empty mongo pipelines', () => {
+    const mongoPipeline: MongoStep[] = [];
+    expect(_simplifyMongoPipeline(mongoPipeline)).to.eql([]);
+  });
+
   it('can simplify a mongo pipeline', () => {
     const mongoPipeline: MongoStep[] = [
       { $match: { domain: 'test_cube' } },


### PR DESCRIPTION
Before this commit, `simplifyMongoPipeline` would output a `[null]`
mongo pipeline if fed with an empty one. This is of course incorrect and
is caused by the following statements at the beginning of the function:

```typescript
  const outputSteps: MongoStep[] = [];
  let lastStep: MongoStep = mongoSteps[0];
  outputSteps.push(lastStep);
```

This commit doesn't change this specific logic but instead explicitly
tests for an empty input pipeline and return another empty one in that
case.