### PR TITLE
PR :: UI Aggregate Step

### DIFF
--- a/src/assets/schemas/aggregate-step__schema.json
+++ b/src/assets/schemas/aggregate-step__schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Aggregate step",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "enum": [
+        "aggregate"
+      ]
+    },
+    "on": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "title": "Group by",
+      "description": "The columns used to group the data for aggregation",
+      "attrs": {
+        "placeholder": "Add columns"
+      }
+    },
+    "aggregations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "column": {
+            "type": "string",
+            "minLength": 1
+          },
+          "aggfunction": {
+            "type": "string",
+            "enum": [
+              "sum",
+              "avg",
+              "count",
+              "min",
+              "max"
+            ]
+          },
+          "newcolumn": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["column", "aggfunction", "newcolumn"],
+        "additionalProperties": false
+      },
+      "minItems": 1,
+      "title": "Aggregations",
+      "description": "The aggregations to be performed"
+    }
+  },
+  "required": ["name", "on", "aggregations"],
+  "additionalProperties": false
+}

--- a/src/components/ActionToolbar.vue
+++ b/src/components/ActionToolbar.vue
@@ -5,12 +5,12 @@
         <i class="action-toolbar__btn-icon fas fa-plus"></i>
         <span class="action-toolbar__btn-txt">Column</span>
       </button>
-
       <action-toolbar-button
-        v-for="button in buttons"
+        v-for="(button, index) in buttons"
         :icon="button.icon"
         :label="button.label"
         :key="button.icon"
+        @click.native="openForm(index)"
       />
       <div class="action-toolbar__search">
         <i class="action-toolbar__search-icon fas fa-search"></i>
@@ -22,18 +22,30 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
+import { State } from 'vuex-class';
 import ActionToolbarButton from './ActionToolbarButton.vue';
 import { ButtonDef } from './constants';
-
 
 @Component({
   name: 'action-toolbar',
   components: {
     ActionToolbarButton,
-  }
+  },
 })
 export default class ActionToolbar extends Vue {
   @Prop(Array) readonly buttons!: ButtonDef[];
+  @State selectedColumns!: string[];
+
+  openForm(index: number) {
+    const buttondef = this.buttons[index];
+    if (buttondef.label === 'Aggregate') {
+      this.createAggregateStep();
+    }
+  }
+
+  createAggregateStep() {
+    this.$emit('actionClicked', { name: 'aggregate', on: this.selectedColumns, aggregations: [] });
+  }
 }
 </script>
 <style lang="scss">

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="!isEmpty" class="data-viewer-container">
-    <ActionToolbar :buttons="buttons"></ActionToolbar>
+    <ActionToolbar :buttons="buttons" @actionClicked="createStep"></ActionToolbar>
     <table class="data-viewer-table">
       <thead class="data-viewer__header">
         <tr>

--- a/src/components/Vqb.vue
+++ b/src/components/Vqb.vue
@@ -100,19 +100,23 @@ export default class Vqb extends Vue {
   height: 100%;
   background-color: white;
 }
+
 .slide-left-enter,
 .slide-left-leave-to {
   transform: translateX(-100%);
   opacity: 0;
 }
+
 .slide-left-enter-active {
   transition: all 0.3s ease;
 }
+
 .slide-right-enter,
 .slide-right-leave-to {
   transform: translateX(100%);
   opacity: 0;
 }
+
 .slide-right-enter-active {
   transition: all 0.3s ease;
 }

--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -1,0 +1,116 @@
+<template>
+  <div>
+    <step-form-title :title="title"></step-form-title>
+    <WidgetMultiselect
+      id="groupbyColumnsInput"
+      v-model="editedStep.on"
+      name="Group by:"
+      :options="columnNames"
+      @input="setSelectedColumns({ column: editedStep.on[0] })"
+      placeholder="Add columns"
+    ></WidgetMultiselect>
+    <WidgetList
+      addFieldName="Add aggregation"
+      id="toremove"
+      name="Aggregations:"
+      v-model="aggregations"
+      :defaultItem="defaultAggregation"
+      :widget="'widget-aggregation'"
+      :automatic-new-field="false"
+    ></WidgetList>
+    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+  </div>
+</template>
+
+<script lang="ts">
+import { Prop } from 'vue-property-decorator';
+import { AggFunctionStep, AggregationStep } from '@/lib/steps';
+import aggregateSchema from '@/assets/schemas/aggregate-step__schema.json';
+import WidgetMultiselect from './WidgetMultiselect.vue';
+import WidgetList from './WidgetList.vue';
+import BaseStepForm from './StepForm.vue';
+import { StepFormComponent } from '@/components/formlib';
+
+@StepFormComponent({
+  vqbstep: 'aggregate',
+  name: 'aggregate-step-form',
+  components: {
+    WidgetList,
+    WidgetMultiselect,
+  },
+})
+export default class AggregateStepForm extends BaseStepForm<AggregationStep> {
+  @Prop({ type: Object, default: () => ({ name: 'aggregate', on: [], aggregations: [] }) })
+  initialStepValue!: AggregationStep;
+
+  readonly title: string = 'Delete Column Step';
+
+  editedStepModel = aggregateSchema;
+
+  get defaultAggregation() {
+    const agg: AggFunctionStep = {
+      column: '',
+      newcolumn: '',
+      aggfunction: 'sum',
+    };
+    return agg;
+  }
+
+  get aggregations() {
+    if (this.editedStep.aggregations.length) {
+      return this.editedStep.aggregations;
+    } else {
+      return [this.defaultAggregation];
+    }
+  }
+
+  set aggregations(newval) {
+    this.editedStep.aggregations = [...newval];
+  }
+
+  submit() {
+    /**
+     * If different aggregations have to be performed on the same column, add a suffix
+     * to the automatically generated newcolumn name
+     */
+    const newcolumnOccurences: { [prop: string]: number } = {};
+    for (const agg of this.editedStep.aggregations) {
+      agg.newcolumn = agg.column;
+      newcolumnOccurences[agg.newcolumn] = (newcolumnOccurences[agg.newcolumn] || 0) + 1;
+    }
+    for (const agg of this.editedStep.aggregations) {
+      if (newcolumnOccurences[agg.newcolumn] > 1) {
+        agg.newcolumn = `${agg.newcolumn}-${agg.aggfunction}`;
+      }
+    }
+    this.$$super.submit();
+  }
+}
+</script>
+<style lang="scss" scoped>
+@import '../../styles/_variables';
+.widget-form-action__button {
+  @extend %button-default;
+}
+
+.widget-form-action__button--validate {
+  background-color: $active-color;
+}
+
+.step-edit-form {
+  border-bottom: 1px solid $grey;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding-bottom: 20px;
+  margin: 10px 0 15px;
+  width: 100%;
+}
+
+.step-edit-form__title {
+  color: $base-color;
+  font-weight: 600;
+  font-size: 14px;
+  margin: 0;
+}
+</style>

--- a/src/components/stepforms/WidgetAggregation.vue
+++ b/src/components/stepforms/WidgetAggregation.vue
@@ -1,0 +1,85 @@
+<template>
+  <fieldset class="widget-aggregation__container">
+    <WidgetAutocomplete
+      id="columnInput"
+      :options="columnNames"
+      v-model="aggregation.column"
+      name="Column"
+      placeholder="Enter a column"
+    ></WidgetAutocomplete>
+    <WidgetAutocomplete
+      id="aggregationFunctionInput"
+      v-model="aggregation.aggfunction"
+      name="Function"
+      :options="aggregationFunctions"
+      placeholder="Aggregation function"
+    ></WidgetAutocomplete>
+  </fieldset>
+</template>
+<script lang="ts">
+import _ from 'lodash';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { Getter } from 'vuex-class';
+import { AggFunctionStep } from '@/lib/steps';
+import WidgetAutocomplete from './WidgetAutocomplete.vue';
+
+const defaultValues: AggFunctionStep = {
+  column: '',
+  aggfunction: 'sum',
+  newcolumn: '',
+};
+
+@Component({
+  name: 'widget-aggregation',
+  components: {
+    WidgetAutocomplete,
+  },
+})
+export default class WidgetAggregation extends Vue {
+  @Prop({
+    type: Object,
+  })
+  value!: AggFunctionStep;
+
+  @Getter columnNames!: string[];
+
+  aggregation: AggFunctionStep = { ...this.value };
+  aggregationFunctions: AggFunctionStep['aggfunction'][] = ['sum', 'avg', 'count', 'min', 'max'];
+
+  created() {
+    if (_.isEmpty(this.value)) {
+      this.value = { ...defaultValues };
+    }
+  }
+
+  @Watch('value', { immediate: true, deep: true })
+  onAggregationChanged(newval: AggFunctionStep, oldval: AggFunctionStep) {
+    if (!_.isEqual(newval, oldval)) {
+      this.aggregation = { ...newval };
+      this.$emit('input', this.aggregation);
+    }
+  }
+}
+</script>
+<style lang="scss" scoped>
+@import '../../styles/_variables';
+.widget-aggregation__container {
+  @extend %form-widget__container;
+  margin-bottom: 0;
+  padding-top: 12px;
+  padding-bottom: 4px;
+}
+
+.widget-autocomplete__container {
+  align-items: center;
+  flex-direction: row;
+  margin-bottom: 8px;
+}
+</style>
+
+<style lang="scss">
+.widget-aggregation__container .widget-autocomplete__label {
+  margin-bottom: 0px;
+  width: 40%;
+}
+</style>

--- a/src/components/stepforms/WidgetList.vue
+++ b/src/components/stepforms/WidgetList.vue
@@ -1,0 +1,160 @@
+<template>
+  <div class="widget-list__container">
+    <label :for="id">{{name}}</label>
+    <div class="widget-list__body">
+      <div class="widget-list__child" v-for="(child, index) in children" :key="index">
+        <div class="widget-list__component">
+          <component :is="widget" :value="child.value" @input="updateChildValue($event, index)"></component>
+        </div>
+        <div class="widget-list__icon" v-if="child.isRemovable" @click="removeChild(index)">
+          <i class="far fa-trash-alt"></i>
+        </div>
+      </div>
+      <button v-if="!automaticNewField" class="widget-list__add-fieldset" @click="addFieldSet">
+        <i class="fas fa-plus-circle"></i>
+        {{ addFieldName }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { AggFunctionStep } from '@/lib/steps';
+import WidgetInputText from './WidgetInputText.vue';
+import WidgetAggregation from './WidgetAggregation.vue';
+
+type Field = {
+  name: string;
+  label?: string;
+  value: any;
+};
+
+type RepeatableField = Field[];
+
+@Component({
+  name: 'widget-list',
+  components: {
+    WidgetAggregation,
+    WidgetInputText,
+  },
+})
+export default class WidgetList extends Vue {
+  @Prop({ type: String, default: '' })
+  addFieldName!: string;
+
+  @Prop({ type: String, default: null })
+  id!: string;
+
+  @Prop({ type: String, default: '' })
+  name!: string;
+
+  @Prop({ type: Array, default: () => [] })
+  value!: any[];
+
+  @Prop({ type: String, default: 'widget-input-text' })
+  widget!: string;
+
+  @Prop({ type: Boolean, default: true })
+  automaticNewField!: boolean;
+
+  @Prop({ default: null })
+  defaultItem!: string | RepeatableField;
+
+  get children() {
+    const valueCopy = [...this.value];
+    if (this.automaticNewField) {
+      valueCopy.push(this.defaultChildValue);
+    }
+    return valueCopy.map(value => ({
+      isRemovable: valueCopy.length !== 1,
+      value,
+    }));
+  }
+
+  get defaultChildValue() {
+    if (this.defaultItem) {
+      return this.defaultItem;
+    }
+    if (this.widget === 'widget-input-text') {
+      return '';
+    } else {
+      return [];
+    }
+  }
+
+  addFieldSet() {
+    this.updateValue([...this.value, this.defaultChildValue]);
+  }
+
+  removeChild(index: number) {
+    const newValue = [...this.value];
+    newValue.splice(index, 1);
+    this.updateValue(newValue);
+  }
+
+  updateChildValue(childValue: any, index: number) {
+    const newValue = [...this.value];
+    if (this.value.length < index) {
+      newValue.push(childValue);
+    } else {
+      newValue[index] = childValue;
+    }
+    this.updateValue(newValue);
+  }
+
+  updateValue(newValue: AggFunctionStep[]) {
+    this.$emit('input', newValue);
+  }
+}
+</script>
+<style lang="scss" scoped>
+@import '../../styles/_variables';
+.fa-plus-circle {
+  color: $active-color;
+}
+.widget-list__container {
+  @extend %form-widget__container;
+}
+
+.widget-list__container label {
+  @extend %form-widget__label;
+}
+
+.widget-list__body {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.widget-list__child {
+  width: 100%;
+  padding-right: 15px;
+  position: relative;
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+}
+
+.widget-list__component {
+  background-color: #f8f8f8;
+  width: 98%;
+}
+
+.widget-list__add-fieldset {
+  @extend %button-default;
+  align-self: center;
+  background-color: #f8f8f8;
+  border: 1px dashed $active-color;
+  color: $active-color;
+  font-weight: 500;
+  width: 250px;
+}
+
+.widget-list__icon {
+  position: absolute;
+  right: 0;
+  top: calc(50% - 16px);
+  cursor: pointer;
+}
+</style>

--- a/src/components/stepforms/WidgetMultiselect.vue
+++ b/src/components/stepforms/WidgetMultiselect.vue
@@ -1,0 +1,147 @@
+<template>
+  <div class="widget-multiselect__container">
+    <label class="widget-multiselect__label" :for="id">{{ name }}</label>
+    <multiselect
+      v-model="editedValue"
+      :options="options"
+      :placeholder="placeholder"
+      :multiple="true"
+      :taggable="true"
+      :close-on-select="false"
+    ></multiselect>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import Multiselect from 'vue-multiselect';
+
+@Component({
+  name: 'widget-multiselect',
+  components: {
+    Multiselect,
+  },
+})
+export default class WidgetMultiselect extends Vue {
+  @Prop({ type: String, default: null })
+  id!: string;
+
+  @Prop({ type: String, default: '' })
+  name!: string;
+
+  @Prop({ type: String, default: '' })
+  placeholder!: string;
+
+  @Prop({ type: Array, default: () => [] })
+  value!: string[];
+
+  @Prop({ type: Array, default: () => [] })
+  options!: string[];
+
+  editedValue: string[] = [];
+
+  @Watch('value', { immediate: true })
+  updateEditedValue(newValue: string[]) {
+    this.editedValue = newValue;
+  }
+
+  @Watch('editedValue')
+  updateValue(newValue: string[]) {
+    this.$emit('input', newValue);
+  }
+}
+</script>
+
+<style src="vue-multiselect/dist/vue-multiselect.min.css"></style>
+<style lang="scss">
+@import '../../styles/_variables';
+.widget-multiselect__container {
+  @extend %form-widget__container;
+  position: relative;
+}
+
+.multiselect {
+  color: $base-color-light;
+  font-size: 14px;
+}
+
+.multiselect__placeholder {
+  margin-bottom: 0;
+  color: #a7a7a7;
+}
+
+.multiselect__single {
+  background-color: transparent;
+  color: $base-color-light;
+  font-size: 14px;
+  margin-bottom: 0;
+}
+
+.multiselect--active {
+  & > .multiselect__tags {
+    @extend %form-widget__field--focused;
+  }
+}
+
+.multiselect__option {
+  font-size: 14px;
+  box-shadow: inset 0 -1px 0 0 #f1f1f1;
+  &:after {
+    display: none;
+  }
+}
+
+.multiselect__option--selected {
+  background-color: $active-color;
+  color: $base-color-light;
+  font-weight: normal;
+  color: #fff;
+}
+
+.multiselect__option--selected.multiselect__option--highlight {
+  background-color: $active-color;
+  color: #fff;
+}
+
+.multiselect__option--highlight {
+  background-color: #f8f8f8;
+  color: $base-color-light;
+}
+
+.widget-multiselect__label {
+  @extend %form-widget__label;
+}
+
+.multiselect__tags {
+  @extend %form-widget__field;
+  border-radius: 0;
+  border: none;
+  font-size: 14px;
+  max-height: none;
+  display: block;
+  padding-right: 30px;
+  & > input {
+    background: transparent;
+    margin-bottom: 0;
+    &::placeholder {
+      color: #a7a7a7;
+    }
+  }
+}
+
+.multiselect__tags .multiselect__tag {
+  background: $active-color;
+}
+
+.multiselect__tags .multiselect__tag-icon {
+  background: $active-color;
+  &:after {
+    // color: #fff;
+    // color: $grey;
+    color: rgba(255, 255, 255, 0.75);
+  }
+  &:hover {
+    background: $active-color;
+  }
+}
+</style>

--- a/src/components/stepforms/index.ts
+++ b/src/components/stepforms/index.ts
@@ -1,3 +1,4 @@
+import './AggregateStepForm.vue';
 import './DeleteColumnStepForm.vue';
 import './FillnaStepForm.vue';
 import './FilterStepForm.vue';

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -4,7 +4,7 @@
 
 type PrimitiveType = number | boolean | string | Date;
 
-type AggFunctionStep = {
+export type AggFunctionStep = {
   /** Name of the output column */
   newcolumn: string;
   /** the aggregation operation (e.g. `sum` or `count`) */

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -119,8 +119,10 @@ export default {
    *
    * set selected columns
    */
-  setSelectedColumns(state: VQBState, { column }: { column: string }) {
-    state.selectedColumns = [column];
+  setSelectedColumns(state: VQBState, { column }: { column: string | undefined }) {
+    if (column !== undefined) {
+      state.selectedColumns = [column];
+    }
   },
 
   /**

--- a/src/styles/ResizablePanels.scss
+++ b/src/styles/ResizablePanels.scss
@@ -7,13 +7,13 @@
 .resizable-panels__panel {
   padding: 10px 15px;
   max-height: 100%;
-  overflow-x: hidden;
+  overflow: auto;
 }
 
 .resizable-panels__resizer {
   display: flex;
   justify-content: space-around;
-  width: 3px;
+  width: 5px;
   border-left: 1px solid rgba(0, 0, 0, 0.3);
   border-right: 1px solid rgba(0, 0, 0, 0.3);
   cursor: ew-resize;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -29,6 +29,10 @@ button {
   outline: none;
 }
 
+fieldset {
+  border: none;
+}
+
 // FORMS STYLES PLACEHOLDER
 %form-widget__container {
   display: flex;
@@ -52,19 +56,23 @@ button {
   background-color: #f8f8f8;
   box-shadow: 0 0 0 1px #f1f1f1 inset;
   border: none;
-  display: flex;
-  flex-direction: row;
   font-family: 'Montserrat', sans-serif;
   font-size: 14px;
   transition: box-shadow 0.25s;
   color: #4c4c4c;
   line-height: 24px;
-  max-height: 40px;
   width: 100%;
-  padding: 8px;
+  padding: 8px 30px 8px 8px;
   outline: none;
+
   box-size &::placeholder {
     color: #a7a7a7;
+  }
+}
+
+.widget-list__container {
+  %form-widget__field {
+    background-color: white;
   }
 }
 

--- a/tests/unit/action-toolbar.spec.ts
+++ b/tests/unit/action-toolbar.spec.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import ActionToolbar from '@/components/ActionToolbar.vue';
+import ActionToolbarButton from '@/components/ActionToolbarButton.vue';
+import Vuex from 'vuex';
+import { setupStore } from '@/store';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('Action Toolbar', () => {
+  it('should instantiate', () => {
+    const wrapper = shallowMount(ActionToolbar);
+    expect(wrapper.exists()).to.be.true;
+  });
+
+  it('should istantiate an aggregate button', () => {
+    const wrapper = mount(ActionToolbar, {
+      propsData: {
+        buttons: [{ label: 'Aggregate' }],
+      },
+    });
+    const buttons = wrapper.find(ActionToolbarButton);
+    expect(buttons.exists()).to.be.true;
+    expect(buttons.props().label).to.eql('Aggregate');
+  });
+
+  it('should emit an actionClicked event only on an aggregate button', () => {
+    const store = setupStore();
+    const wrapper = mount(ActionToolbar, {
+      store,
+      localVue,
+      propsData: {
+        buttons: [{ label: 'Filter' }, { label: 'Aggregate' }],
+      },
+    });
+    const buttons = wrapper.findAll(ActionToolbarButton);
+    buttons.at(0).trigger('click');
+    expect(wrapper.emitted().actionClicked).not.to.exist;
+    buttons.at(1).trigger('click');
+    expect(wrapper.emitted().actionClicked[0]).to.eql([
+      { name: 'aggregate', on: [], aggregations: [] },
+    ]);
+  });
+});

--- a/tests/unit/aggregate-step-form.spec.ts
+++ b/tests/unit/aggregate-step-form.spec.ts
@@ -1,0 +1,287 @@
+import { expect } from 'chai';
+import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import AggregateStepForm from '@/components/stepforms/AggregateStepForm.vue';
+import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
+import WidgetMultiselect from '@/components/stepforms/WidgetMultiselect.vue';
+import Vuex, { Store } from 'vuex';
+import { setupStore } from '@/store';
+import { Pipeline } from '@/lib/steps';
+import { VQBState } from '@/store/state';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+interface ValidationError {
+  dataPath: string;
+  keyword: string;
+}
+
+describe('Aggregate Step Form', () => {
+  let emptyStore: Store<VQBState>;
+  beforeEach(() => {
+    emptyStore = setupStore({});
+  });
+
+  it('should instantiate', () => {
+    const wrapper = shallowMount(AggregateStepForm, { store: emptyStore, localVue });
+    expect(wrapper.exists()).to.be.true;
+  });
+
+  describe('WidgetMultiselect', () => {
+    it('should have exactly one WidgetMultiselect component', () => {
+      const wrapper = shallowMount(AggregateStepForm, { store: emptyStore, localVue });
+      const widgetWrappers = wrapper.findAll('widgetmultiselect-stub');
+      expect(widgetWrappers.length).to.equal(1);
+    });
+
+    it('should instantiate an WidgetMultiselect widget with proper options from the store', () => {
+      const store = setupStore({
+        dataset: {
+          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+          data: [],
+        },
+      });
+      const wrapper = shallowMount(AggregateStepForm, { store, localVue });
+      const widgetMultiselect = wrapper.find('widgetmultiselect-stub');
+      expect(widgetMultiselect.attributes('options')).to.equal('columnA,columnB,columnC');
+    });
+
+    it('should pass down the "on" prop to the WidgetMultiselect value prop', async () => {
+      const wrapper = shallowMount(AggregateStepForm, { store: emptyStore, localVue });
+      wrapper.setData({ editedStep: { name: 'aggregate', on: ['foo', 'bar'], aggregations: [] } });
+      await localVue.nextTick();
+      expect(wrapper.find('widgetmultiselect-stub').props().value).to.eql(['foo', 'bar']);
+    });
+
+    it('should call the setColumnMutation on input', async () => {
+      const store = emptyStore;
+      const wrapper = mount(AggregateStepForm, { store, localVue });
+      wrapper.setData({ editedStep: { name: 'aggregate', on: ['foo'], aggregations: [] } });
+      await wrapper.find(WidgetMultiselect).trigger('input');
+      expect(store.state.selectedColumns).to.eql(['foo']);
+    });
+  });
+
+  describe('WidgetList', () => {
+    it('should have exactly on WidgetList component', () => {
+      const wrapper = shallowMount(AggregateStepForm, { store: emptyStore, localVue });
+      const widgetWrappers = wrapper.findAll('widgetlist-stub');
+      expect(widgetWrappers.length).to.equal(1);
+    });
+
+    it('should pass down the "aggregations" prop to the WidgetList value prop', async () => {
+      const wrapper = shallowMount(AggregateStepForm, { store: emptyStore, localVue });
+      wrapper.setData({
+        editedStep: {
+          name: 'aggregate',
+          on: [],
+          aggregations: [{ column: 'foo', newcolumn: 'bar', aggfunction: 'sum' }],
+        },
+      });
+      await localVue.nextTick();
+      expect(wrapper.find('widgetlist-stub').props().value).to.eql([
+        { column: 'foo', newcolumn: 'bar', aggfunction: 'sum' },
+      ]);
+    });
+
+    it('should have expected default aggregation parameters', () => {
+      const wrapper = mount(AggregateStepForm, { store: emptyStore, localVue });
+      const widgetWrappers = wrapper.findAll(WidgetAutocomplete);
+      expect(widgetWrappers.at(0).props().value).to.equal('');
+      expect(widgetWrappers.at(1).props().value).to.equal('sum');
+    });
+  });
+
+  describe('Validation', () => {
+    it('should report errors when the "on" parameter is an empty string', async () => {
+      const wrapper = mount(AggregateStepForm, {
+        store: emptyStore,
+        localVue,
+        data: () => {
+          return {
+            editedStep: {
+              name: 'aggregate',
+              on: [''],
+              aggregations: [{ column: 'foo', newcolumn: 'bar', aggfunction: 'sum' }],
+            },
+          };
+        },
+      });
+      wrapper.find('.widget-form-action__button--validate').trigger('click');
+      await localVue.nextTick();
+      const errors = wrapper.vm.$data.errors
+        .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
+        .sort((err1: ValidationError, err2: ValidationError) =>
+          err1.dataPath.localeCompare(err2.dataPath),
+        );
+      expect(errors).to.eql([{ keyword: 'minLength', dataPath: '.on[0]' }]);
+    });
+
+    it('should report errors when the "column" parameter is an empty string', async () => {
+      const wrapper = mount(AggregateStepForm, {
+        store: emptyStore,
+        localVue,
+        data: () => {
+          return {
+            editedStep: {
+              name: 'aggregate',
+              on: ['foo'],
+              aggregations: [{ column: '', newcolumn: 'bar', aggfunction: 'sum' }],
+            },
+          };
+        },
+      });
+      wrapper.find('.widget-form-action__button--validate').trigger('click');
+      await localVue.nextTick();
+      const errors = wrapper.vm.$data.errors
+        .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
+        .sort((err1: ValidationError, err2: ValidationError) =>
+          err1.dataPath.localeCompare(err2.dataPath),
+        );
+      expect(errors).to.eql([
+        { keyword: 'minLength', dataPath: '.aggregations[0].column' },
+        // newcolumn is computed based on column so an error is also returned for this parameter
+        { keyword: 'minLength', dataPath: '.aggregations[0].newcolumn' },
+      ]);
+    });
+
+    it('should report errors when the "aggfunction" parameter is not allowed', async () => {
+      const wrapper = mount(AggregateStepForm, {
+        store: emptyStore,
+        localVue,
+        data: () => {
+          return {
+            editedStep: {
+              name: 'aggregate',
+              on: ['foo'],
+              aggregations: [{ column: 'foo', newcolumn: 'bar', aggfunction: '' }],
+            },
+          };
+        },
+      });
+      wrapper.find('.widget-form-action__button--validate').trigger('click');
+      await localVue.nextTick();
+      const errors = wrapper.vm.$data.errors
+        .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
+        .sort((err1: ValidationError, err2: ValidationError) =>
+          err1.dataPath.localeCompare(err2.dataPath),
+        );
+      expect(errors).to.eql([{ keyword: 'enum', dataPath: '.aggregations[0].aggfunction' }]);
+    });
+
+    it('should keep the same column name as newcolumn if only one aggregation is performed', async () => {
+      const wrapper = mount(AggregateStepForm, {
+        store: emptyStore,
+        localVue,
+        data: () => {
+          return {
+            editedStep: {
+              name: 'aggregate',
+              on: ['foo'],
+              aggregations: [{ column: 'bar', newcolumn: '', aggfunction: 'sum' }],
+            },
+          };
+        },
+      });
+      wrapper.find('.widget-form-action__button--validate').trigger('click');
+      await localVue.nextTick();
+      expect(wrapper.vm.$data.errors).to.be.null;
+      expect(wrapper.vm.$data.editedStep.aggregations[0].newcolumn).to.equal('bar');
+    });
+
+    it('should set newcolumn cleverly if several aggregations are performed o, the same column', async () => {
+      const wrapper = mount(AggregateStepForm, {
+        store: emptyStore,
+        localVue,
+        data: () => {
+          return {
+            editedStep: {
+              name: 'aggregate',
+              on: ['foo'],
+              aggregations: [
+                { column: 'bar', newcolumn: '', aggfunction: 'sum' },
+                { column: 'bar', newcolumn: '', aggfunction: 'avg' },
+              ],
+            },
+          };
+        },
+      });
+      wrapper.find('.widget-form-action__button--validate').trigger('click');
+      await localVue.nextTick();
+      expect(wrapper.vm.$data.errors).to.be.null;
+      expect(wrapper.vm.$data.editedStep.aggregations[0].newcolumn).to.equal('bar-sum');
+      expect(wrapper.vm.$data.editedStep.aggregations[1].newcolumn).to.equal('bar-avg');
+    });
+
+    it('should validate and emit "formSaved" when submitted data is valid', async () => {
+      const wrapper = mount(AggregateStepForm, {
+        store: emptyStore,
+        localVue,
+        data: () => {
+          return {
+            editedStep: {
+              name: 'aggregate',
+              on: ['foo'],
+              aggregations: [{ column: 'bar', newcolumn: '', aggfunction: 'sum' }],
+            },
+          };
+        },
+      });
+      wrapper.find('.widget-form-action__button--validate').trigger('click');
+      await localVue.nextTick();
+      expect(wrapper.vm.$data.errors).to.be.null;
+      expect(wrapper.emitted()).to.eql({
+        formSaved: [
+          [
+            {
+              name: 'aggregate',
+              on: ['foo'],
+              aggregations: [{ column: 'bar', newcolumn: 'bar', aggfunction: 'sum' }],
+            },
+          ],
+        ],
+      });
+    });
+  });
+
+  it('should emit "cancel" event when edition is cancelled', async () => {
+    const wrapper = mount(AggregateStepForm, { store: emptyStore, localVue });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    await localVue.nextTick();
+    expect(wrapper.emitted()).to.eql({
+      cancel: [[]],
+    });
+  });
+
+  it('should change the column focus after input in multiselect', async () => {
+    const store = setupStore({ selectedColumns: [] });
+    const wrapper = mount(AggregateStepForm, { store, localVue });
+    wrapper.setData({ editedStep: { name: 'aggregate', on: ['foo'], aggregations: [] } });
+    wrapper.find(WidgetMultiselect).trigger('input');
+    await localVue.nextTick();
+    expect(store.state.selectedColumns).to.eql(['foo']);
+  });
+
+  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+      { name: 'rename', oldname: 'baz', newname: 'spam' },
+      { name: 'rename', oldname: 'tic', newname: 'tac' },
+    ];
+    const store = setupStore({
+      pipeline,
+      selectedStepIndex: 2,
+    });
+    const wrapper = mount(AggregateStepForm, {
+      store,
+      localVue,
+      propsData: { isStepCreation: true },
+    });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    expect(store.state.selectedStepIndex).to.equal(2);
+    wrapper.setProps({ isStepCreation: false });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    expect(store.state.selectedStepIndex).to.equal(3);
+  });
+});

--- a/tests/unit/karma-test-suite.ts
+++ b/tests/unit/karma-test-suite.ts
@@ -18,6 +18,7 @@ import './step.spec';
 import './store.spec';
 import './translator.spec';
 import './vqb.spec';
+import './widget-aggregation.spec';
 import './widget-autocomplete.spec';
 import './widget-input-text.spec';
 import './widget-multiselect.spec.ts';

--- a/tests/unit/karma-test-suite.ts
+++ b/tests/unit/karma-test-suite.ts
@@ -21,4 +21,5 @@ import './vqb.spec';
 import './widget-aggregation.spec';
 import './widget-autocomplete.spec';
 import './widget-input-text.spec';
+import './widget-list.spec';
 import './widget-multiselect.spec.ts';

--- a/tests/unit/karma-test-suite.ts
+++ b/tests/unit/karma-test-suite.ts
@@ -1,4 +1,5 @@
 import './action-menu.spec';
+import './aggregate-step-form.spec';
 import './dataset.spec';
 import './data-viewer-cell.spec';
 import './data-viewer.spec';

--- a/tests/unit/karma-test-suite.ts
+++ b/tests/unit/karma-test-suite.ts
@@ -20,3 +20,4 @@ import './translator.spec';
 import './vqb.spec';
 import './widget-autocomplete.spec';
 import './widget-input-text.spec';
+import './widget-multiselect.spec.ts';

--- a/tests/unit/karma-test-suite.ts
+++ b/tests/unit/karma-test-suite.ts
@@ -1,4 +1,5 @@
 import './action-menu.spec';
+import './action-toolbar.spec';
 import './aggregate-step-form.spec';
 import './dataset.spec';
 import './data-viewer-cell.spec';

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -265,4 +265,16 @@ describe('mutation tests', () => {
     mutations.toggleStepEdition(state);
     expect(state.isEditingStep).to.be.true;
   });
+
+  it('sets selected columns', () => {
+    const state = buildState({});
+    mutations.setSelectedColumns(state, { column: 'foo' });
+    expect(state.selectedColumns).to.eql(['foo']);
+  });
+
+  it('does not set selected columns if payload is undefined', () => {
+    const state = buildState({});
+    mutations.setSelectedColumns(state, { column: undefined });
+    expect(state.selectedColumns).to.eql([]);
+  });
 });

--- a/tests/unit/vqb.spec.ts
+++ b/tests/unit/vqb.spec.ts
@@ -15,6 +15,19 @@ describe('Vqb', () => {
     expect(wrapper.vm.$store.state.isEditingStep).to.be.false;
   });
 
+  it('should instantiate a AggregateStepForm component', () => {
+    const store = setupStore({ isEditingStep: true });
+    const wrapper = shallowMount(Vqb, {
+      store,
+      localVue,
+      data: () => {
+        return { formToInstantiate: 'aggregate-step-form' };
+      },
+    });
+    const form = wrapper.find('aggregate-step-form-stub');
+    expect(form.exists()).to.be.true;
+  });
+
   it('should instantiate a FormRenameStep component', () => {
     const store = setupStore({ isEditingStep: true });
     const wrapper = shallowMount(Vqb, {

--- a/tests/unit/widget-aggregation.spec.ts
+++ b/tests/unit/widget-aggregation.spec.ts
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import WidgetAggregation from '@/components/stepforms/WidgetAggregation.vue';
+import Vuex, { Store } from 'vuex';
+import { setupStore } from '@/store';
+import { VQBState } from '@/store/state';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('Widget WidgetAggregation', () => {
+  let emptyStore: Store<VQBState>;
+  beforeEach(() => {
+    emptyStore = setupStore({});
+  });
+
+  it('should instantiate', () => {
+    const wrapper = shallowMount(WidgetAggregation, { store: emptyStore, localVue });
+    expect(wrapper.exists()).to.be.true;
+  });
+
+  it('should have exactly two WidgetAutocomplete components', () => {
+    const wrapper = shallowMount(WidgetAggregation, { store: emptyStore, localVue });
+    const widgetWrappers = wrapper.findAll('widgetautocomplete-stub');
+    expect(widgetWrappers.length).to.eql(2);
+  });
+
+  it('should instantiate an widgetAutocomplete widget with proper options from the store', () => {
+    const store = setupStore({
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+    });
+    const wrapper = shallowMount(WidgetAggregation, { store, localVue });
+    const widgetWrappers = wrapper.findAll('widgetautocomplete-stub');
+    expect(widgetWrappers.at(0).attributes('options')).to.equal('columnA,columnB,columnC');
+  });
+
+  it('should pass down the "column" prop to the first WidgetAutocomplete value prop', async () => {
+    const wrapper = shallowMount(WidgetAggregation, { store: emptyStore, localVue });
+    wrapper.setProps({ value: { column: 'foo', newcolumn: '', aggfunction: 'sum' } });
+    await localVue.nextTick();
+    const widgetWrappers = wrapper.findAll('WidgetAutocomplete-stub');
+    expect(widgetWrappers.at(0).props().value).to.eql('foo');
+  });
+
+  it('should pass down the "aggfunction" prop to the second WidgetAutocomplete value prop', async () => {
+    const wrapper = shallowMount(WidgetAggregation, { store: emptyStore, localVue });
+    wrapper.setProps({ value: { column: 'foo', newcolumn: '', aggfunction: 'avg' } });
+    await localVue.nextTick();
+    const widgetWrappers = wrapper.findAll('WidgetAutocomplete-stub');
+    expect(widgetWrappers.at(1).props().value).to.eql('avg');
+  });
+
+  it('should emit "input" event on "value" update', async () => {
+    const wrapper = shallowMount(WidgetAggregation, {
+      store: emptyStore,
+      localVue,
+    });
+    wrapper.setProps({ value: { column: 'bar', newcolumn: '', aggfunction: 'avg' } });
+    await localVue.nextTick();
+    expect(wrapper.emitted().input).to.exist;
+    expect(wrapper.emitted().input[0]).to.eql([
+      { column: 'bar', newcolumn: '', aggfunction: 'avg' },
+    ]);
+  });
+});

--- a/tests/unit/widget-list.spec.ts
+++ b/tests/unit/widget-list.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from 'chai';
+import { shallowMount } from '@vue/test-utils';
+import WidgetList from '@/components/stepforms/WidgetList.vue';
+
+describe('Widget List', () => {
+  describe('automatic new field', () => {
+    it('it should instantiate', () => {
+      const wrapper = shallowMount(WidgetList);
+
+      expect(wrapper.exists()).to.be.true;
+    });
+
+    it('should have a label', () => {
+      const wrapper = shallowMount(WidgetList, {
+        propsData: {
+          name: 'Label',
+        },
+      });
+
+      expect(wrapper.find('label').text()).to.equal('Label');
+    });
+
+    it('should instantiate a widget-input text', () => {
+      const wrapper = shallowMount(WidgetList);
+      const widgetInputWrapper = wrapper.find('widget-input-text-stub');
+
+      expect(widgetInputWrapper.exists()).to.be.true;
+    });
+
+    it('should instantiate a widget aggregation', () => {
+      const wrapper = shallowMount(WidgetList, {
+        propsData: {
+          widget: 'widget-aggregation',
+        },
+      });
+
+      const widgetAggregationtWrapper = wrapper.find('widget-aggregation-stub');
+      expect(widgetAggregationtWrapper.exists()).to.be.true;
+    });
+
+    it('should automatically add an input when filling the first one', async () => {
+      const wrapper = shallowMount(WidgetList);
+      wrapper.setProps({ value: ['columnName'] });
+
+      await wrapper.vm.$nextTick();
+      expect(wrapper.findAll('widget-input-text-stub').length).to.equal(2);
+    });
+
+    it('should add trash icons after first input', async () => {
+      const wrapper = shallowMount(WidgetList);
+      expect(wrapper.findAll('.widget-list__icon').length).to.eql(0);
+      wrapper.setProps({ value: ['columnName'] });
+      await wrapper.vm.$nextTick();
+      expect(wrapper.findAll('.widget-list__icon').length).to.eql(2);
+    });
+
+    it('should remove first input when clickng on trash', async () => {
+      const wrapper = shallowMount(WidgetList, {
+        propsData: {
+          value: ['columnName'],
+        },
+      });
+      const trashWrapper = wrapper.find('.widget-list__icon');
+      trashWrapper.trigger('click');
+      expect(wrapper.emitted()['input']).to.exist;
+    });
+  });
+
+  describe('not automatic new field', () => {
+    it('should have a button to add a new field', () => {
+      const wrapper = shallowMount(WidgetList, {
+        propsData: {
+          automaticNewField: false,
+          name: 'Aggregation',
+          addFieldName: 'Add aggregation',
+        },
+      });
+      const addButtonWrapper = wrapper.find('button');
+
+      expect(addButtonWrapper.exists()).to.be.true;
+      expect(addButtonWrapper.text()).to.equal('Add aggregation');
+    });
+
+    it('should add a new field when clicking on the button "Add Aggregation"', () => {
+      const wrapper = shallowMount(WidgetList, {
+        propsData: {
+          automaticNewField: false,
+          name: 'Aggregation',
+        },
+      });
+      const addButtonWrapper = wrapper.find('button');
+      addButtonWrapper.trigger('click');
+
+      expect(wrapper.emitted()['input']).to.exist;
+      expect(wrapper.emitted()['input'][0][0][0]).to.equal('');
+    });
+  });
+});

--- a/tests/unit/widget-multiselect.spec.ts
+++ b/tests/unit/widget-multiselect.spec.ts
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import { shallowMount } from '@vue/test-utils';
+import WidgetMultiSelect from '@/components/stepforms/WidgetInputText.vue';
+
+describe('Widget Multiselect', () => {
+  it('should instantiate', () => {
+    const wrapper = shallowMount(WidgetMultiSelect);
+
+    expect(wrapper.exists()).to.be.true;
+  });
+
+  it('should have a label', () => {
+    const wrapper = shallowMount(WidgetMultiSelect, {
+      propsData: {
+        name: 'Stark',
+      },
+    });
+    const labelWrapper = wrapper.find('label');
+    expect(labelWrapper.text()).to.equal('Stark');
+  });
+
+  it('should have an empty placeholder', () => {
+    const wrapper = shallowMount(WidgetMultiSelect, {
+      propsData: {
+        value: 'foo',
+      },
+    });
+    const el = wrapper.find("input[type='text']").element as HTMLInputElement;
+    expect(el.placeholder).to.equal('');
+  });
+
+  it('should have a placeholder', () => {
+    const wrapper = shallowMount(WidgetMultiSelect, {
+      propsData: {
+        placeholder: 'I m a placeholder',
+        value: 'foo',
+      },
+    });
+    const el = wrapper.find("input[type='text']").element as HTMLInputElement;
+    expect(el.placeholder).to.equal('I m a placeholder');
+  });
+
+  it('should have an empty input', () => {
+    const wrapper = shallowMount(WidgetMultiSelect);
+    const el = wrapper.find("input[type='text']").element as HTMLInputElement;
+    expect(el.value).to.equal('');
+  });
+
+  it('should have a non empty input', () => {
+    const wrapper = shallowMount(WidgetMultiSelect, {
+      propsData: { value: 'foo' },
+    });
+    const el = wrapper.find("input[type='text']").element as HTMLInputElement;
+    expect(el.value).to.equal('foo');
+  });
+
+  it('should emit "input" event on update', () => {
+    const wrapper = shallowMount(WidgetMultiSelect, {
+      propsData: {
+        value: ['Foo'],
+      },
+    });
+    const inputWrapper = wrapper.find('input[type="text"]');
+    (inputWrapper.element as HTMLInputElement).value = 'Bar';
+    inputWrapper.trigger('input', { value: 'Bar' });
+    expect(wrapper.emitted()).to.eql({ input: [['Bar']] });
+  });
+});


### PR DESCRIPTION
Introduce a complete UI for creating aggregations including:

- A new "WidgetMultiselect" component to manage the selction of multiple columns at once
- A new "WidgetList" component to manage repeatable form inputs

The Aggregate step form can be opened via the "Aggregate" button of the action toolbar.

Closes https://github.com/ToucanToco/vue-query-builder/issues/193
Closes https://github.com/ToucanToco/vue-query-builder/issues/194
Closes https://github.com/ToucanToco/vue-query-builder/issues/195