### PR TITLE
fix :: remove forgotten .only in domain step form tests

### DIFF
--- a/tests/unit/domain-step-form.spec.ts
+++ b/tests/unit/domain-step-form.spec.ts
@@ -13,7 +13,7 @@ interface ValidationError {
   keyword: string;
 }
 
-describe.only('Domain Step Form', () => {
+describe('Domain Step Form', () => {
   let emptyStore: Store<VQBState>;
   beforeEach(() => {
     emptyStore = setupStore({});


### PR DESCRIPTION
Remove a forgotter .only left inside `domain-step-form.spec.ts` file.