### PR TITLE
Feature :: Empty Pipeline

### DIFF
--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -1,16 +1,6 @@
 <template>
   <div class="query-pipeline">
-    <div v-if="isEmpty" class="query-pipeline__empty-container">
-      <div class="query-pipeline__empty-message">
-        Start playing with data right from the table or switch to Code View with
-        <i
-          class="fas fa-code"
-        ></i> !
-      </div>
-      <i class="fas fa-magic"></i>
-    </div>
     <Step
-      v-else
       v-for="(step, index) in steps"
       :key="index"
       :is-active="index < activeStepIndex"
@@ -23,6 +13,12 @@
       @selectedStep="selectStep({ index: index })"
       @editStep="editStep"
     />
+    <div v-if="onlyDomainStepIsPresent" class="query-pipeline__empty-container">
+      <div
+        class="query-pipeline__empty-message"
+      >Start playing with data directly from the right table</div>
+      <i class="fas fa-magic"></i>
+    </div>
   </div>
 </template>
 
@@ -44,11 +40,11 @@ import Step from './Step.vue';
 export default class PipelineComponent extends Vue {
   @State('pipeline') steps!: Pipeline;
   @State domains!: string[];
-  @State('isPipelineEmpty') isEmpty!: boolean;
 
   @Getter activePipeline!: Pipeline;
   @Getter('computedActiveStepIndex') activeStepIndex!: number;
   @Getter domainStep!: DomainStep;
+  @Getter('isPipelineEmpty') onlyDomainStepIsPresent!: boolean;
   @Getter('isStepDisabled') isDisabled!: (index: number) => boolean;
 
   @Mutation selectStep!: MutationCallbacks['selectStep'];

--- a/src/styles/Pipeline.scss
+++ b/src/styles/Pipeline.scss
@@ -18,7 +18,7 @@
   font-size: 24px;
   color: rgb(154, 154, 154);
   margin-top: 120px;
-  margin-bottom: 170px;
+  margin-bottom: 80px;
   text-align: center;
 }
 

--- a/tests/unit/pipeline.spec.ts
+++ b/tests/unit/pipeline.spec.ts
@@ -48,4 +48,16 @@ describe('Pipeline.vue', () => {
       indexInPipeline: 2,
     });
   });
+
+  describe('when only domain step', () => {
+    it('should render a container with message', () => {
+      const pipeline: Pipeline = [{ name: 'domain', domain: 'GoT' }];
+      const store = setupStore({ pipeline });
+      const wrapper = shallowMount(PipelineComponent, { store, localVue });
+      expect(wrapper.find('.query-pipeline__empty-message').text()).to.equal(
+        'Start playing with data directly from the right table',
+      );
+      expect(wrapper.find('.fa-magic').exists()).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
Handle "empty" pipeline (when it only contains a `domain` step) with a clear message to tell the user to start using the table.

UI
<img width="552" alt="Capture d’écran 2019-06-25 à 16 25 41" src="https://user-images.githubusercontent.com/4061263/60107142-b45d9100-9766-11e9-944c-ae67d18e6343.png">
