### PR TITLE
Feature :: Generic way to open forms

### DIFF
--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -4,7 +4,7 @@
       <div class="action-menu__section">
         <div class="action-menu__option">Duplicate column</div>
         <div class="action-menu__option" @click="createStep('rename')">Rename column</div>
-        <div class="action-menu__option" @click="createStep('delete')">Delete column</div>
+        <div class="action-menu__option" @click="createDeleteColumnStep">Delete column</div>
         <div class="action-menu__option" @click="createStep('fillna')">Fill null values</div>
         <div class="action-menu__option" @click="createStep('filter')">Filter values</div>
       </div>

--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -3,10 +3,10 @@
     <div class="action-menu__body">
       <div class="action-menu__section">
         <div class="action-menu__option">Duplicate column</div>
-        <div class="action-menu__option" @click="createRenameStep">Rename column</div>
-        <div class="action-menu__option" @click="createDeleteColumnStep">Delete column</div>
-        <div class="action-menu__option" @click="createFillnaStep">Fill null values</div>
-        <div class="action-menu__option" @click="createFilterStep">Filter values</div>
+        <div class="action-menu__option" @click="createStep('rename')">Rename column</div>
+        <div class="action-menu__option" @click="createStep('delete')">Delete column</div>
+        <div class="action-menu__option" @click="createStep('fillna')">Fill null values</div>
+        <div class="action-menu__option" @click="createStep('filter')">Filter values</div>
       </div>
     </div>
   </popover>
@@ -16,7 +16,7 @@ import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { Getter, Mutation, State } from 'vuex-class';
 import { POPOVER_ALIGN } from '@/components/constants';
 import Popover from './Popover.vue';
-import { Pipeline, PipelineStep } from '@/lib/steps';
+import { Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
 import { MutationCallbacks } from '@/store/mutations';
 
 @Component({
@@ -82,18 +82,8 @@ export default class ActionMenu extends Vue {
     this.close();
   }
 
-  createFillnaStep() {
-    this.$emit('actionClicked', { name: 'fillna', column: this.columnName, value: '' });
-    this.close();
-  }
-
-  createFilterStep() {
-    this.$emit('actionClicked', { name: 'filter', column: this.columnName, value: '', operator: 'eq' });
-    this.close();
-  }
-
-  createRenameStep() {
-    this.$emit('actionClicked', { name: 'rename', oldname: this.columnName, newname: '' });
+  createStep(stepName: PipelineStepName) {
+    this.$emit('actionClicked', stepName);
     this.close();
   }
 

--- a/src/components/ActionToolbar.vue
+++ b/src/components/ActionToolbar.vue
@@ -14,6 +14,7 @@
         :is-active="button.isActionToolbarMenuOpened"
         :class="button.class"
         @click.native="openPopover(index)"
+        @actionClicked="actionClicked"
         @closed="closePopover()"
       />
       <div class="action-toolbar__search">
@@ -29,6 +30,7 @@ import { Component, Prop } from 'vue-property-decorator';
 import { State } from 'vuex-class';
 import ActionToolbarButton from './ActionToolbarButton.vue';
 import { ButtonDef } from './constants';
+import { PipelineStepName } from '@/lib/steps';
 
 @Component({
   name: 'action-toolbar',
@@ -42,17 +44,17 @@ export default class ActionToolbar extends Vue {
 
   isActiveActionToolbarButton: number = -1;
 
+  actionClicked(stepName: PipelineStepName) {
+    this.$emit('actionClicked', stepName);
+  }
+
   openPopover(index: number) {
     const buttondef = this.buttons[index];
     if (buttondef.label === 'Aggregate') {
-      this.createAggregateStep();
+      this.actionClicked('aggregate');
     } else {
       this.isActiveActionToolbarButton = index;
     }
-  }
-
-  createAggregateStep() {
-    this.$emit('actionClicked', { name: 'aggregate', on: this.selectedColumns, aggregations: [] });
   }
 
   get formattedButtons() {

--- a/src/components/ActionToolbarButton.vue
+++ b/src/components/ActionToolbarButton.vue
@@ -9,6 +9,7 @@
             v-for="(item, index) in items"
             :key="index"
             class="action-menu__option"
+            @click="actionClicked(item.name)"
           >{{ item.label }}</div>
         </div>
       </div>
@@ -19,9 +20,9 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
+import { PipelineStepName } from '@/lib/steps';
 import { ACTION_CATEGORIES, POPOVER_ALIGN } from '@/components/constants';
 import Popover from './Popover.vue';
-import { Object } from 'lodash';
 
 @Component({
   name: 'action-toolbar-button',
@@ -57,6 +58,12 @@ export default class ActionToolbarButton extends Vue {
       this.close();
     }
   }
+  /**
+   * @description Emit an event with a PipelineStepName in order to open its form
+   */
+  actionClicked(stepName: PipelineStepName) {
+    this.$emit('actionClicked', stepName);
+  }
 
   get items() {
     return ACTION_CATEGORIES[this.category];
@@ -67,7 +74,7 @@ export default class ActionToolbarButton extends Vue {
   }
 
   @Watch('isActive')
-  onIsActiveChanged(val: boolean, oldval: boolean) {
+  onIsActiveChanged(val: boolean) {
     if (val) {
       window.addEventListener('click', this.clickListener);
     } else {

--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -47,7 +47,7 @@ import Vue from 'vue';
 import { Getter, Mutation, State } from 'vuex-class';
 
 import { DataSet } from '@/lib/dataset';
-import { PipelineStep } from '@/lib/steps';
+import { PipelineStepName } from '@/lib/steps';
 import { Component } from 'vue-property-decorator';
 import ActionMenu from './ActionMenu.vue';
 import ActionToolbar from './ActionToolbar.vue';
@@ -129,10 +129,10 @@ export default class DataViewer extends Vue {
   /**
    * @description Emit an event in order to open the form to create a step
    *
-   * @param {PipelineStep} step - The step we want to create
+   * @param {PipelineStepName} stepName - The name of the step we want to create
    */
-  createStep(step: PipelineStep) {
-    this.$emit('stepCreated', step);
+  createStep(stepName: PipelineStepName) {
+    this.$emit('stepCreated', stepName);
   }
 }
 </script>

--- a/src/components/Vqb.vue
+++ b/src/components/Vqb.vue
@@ -14,7 +14,7 @@
       <transition slot="left-panel" v-else name="slide-left" mode="out-in">
         <Pipeline key="pipeline" @editStep="openStepForm"/>
       </transition>
-      <DataViewer slot="right-panel" @stepCreated="openStepForm"/>
+      <DataViewer slot="right-panel" @stepCreated="createStepForm"/>
     </ResizablePanels>
   </div>
 </template>
@@ -24,7 +24,7 @@ import Vue, { VueConstructor } from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Getter, Mutation, State } from 'vuex-class';
 import { VQBState } from '@/store/state';
-import { Pipeline, PipelineStep } from '@/lib/steps';
+import { Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
 import DataViewer from '@/components/DataViewer.vue';
 import PipelineComponent from '@/components/Pipeline.vue';
 import ResizablePanels from '@/components/ResizablePanels.vue';
@@ -52,10 +52,24 @@ export default class Vqb extends Vue {
   formToInstantiate?: VueConstructor<Vue>;
   initialValue: any = undefined;
   editedStepIndex: number = -1;
-  stepName!: string;
 
   get isStepCreation() {
     return this.editedStepIndex === -1;
+  }
+
+  createStepForm(stepName: PipelineStepName) {
+    if (this.isEditingStep) {
+      this.toggleStepEdition();
+    }
+    this.formToInstantiate = STEPFORM_REGISTRY[stepName];
+    this.initialValue = undefined;
+    if (this.formToInstantiate === undefined) {
+      console.error('No corresponding form for this step');
+      return;
+    }
+    this.editedStepIndex = -1;
+    // Display step edition form in the left panel
+    this.toggleStepEdition();
   }
 
   openStepForm(params: PipelineStep, index: number) {
@@ -69,13 +83,9 @@ export default class Vqb extends Vue {
       return;
     }
     this.initialValue = { ...params }; // make a copy
-    if (index !== undefined) {
-      this.editedStepIndex = index;
-      const prevIndex = Math.max(index - 1, 0);
-      this.selectStep({ index: prevIndex });
-    } else {
-      this.editedStepIndex = -1;
-    }
+    this.editedStepIndex = index;
+    const prevIndex = Math.max(index - 1, 0);
+    this.selectStep({ index: prevIndex });
     // Display step edition form in the left panel
     this.toggleStepEdition();
   }

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -5,7 +5,19 @@ export type ButtonDef = Readonly<{
   enable: boolean;
 }>;
 
-export const ACTION_CATEGORIES: { [category: string]: object } = {
+type ActionCategories = {
+  compute: ActionCategory[];
+  filter: ActionCategory[];
+  reshape: ActionCategory[];
+  [key: string]: ActionCategory[];
+};
+
+export type ActionCategory = {
+  name: string;
+  label: string;
+};
+
+export const ACTION_CATEGORIES: ActionCategories = {
   compute: [{ name: 'percentage', label: 'Percentage of total' }],
   filter: [
     { name: 'filter', label: 'Filter based on conditions' },

--- a/src/components/stepforms/StepForm.vue
+++ b/src/components/stepforms/StepForm.vue
@@ -143,9 +143,9 @@ export default class BaseStepForm<StepType> extends Vue {
    * when selected column is changed, update corresponding field in the step
    * with the `stepSelectedColumn` property.
    */
-  @Watch('selectedColumns')
+  @Watch('selectedColumns', { immediate: true })
   onSelectedColumnsChanged(val: string[], oldVal: string[]) {
-    if (!_.isEqual(val, oldVal)) {
+    if (!_.isEmpty(val) && !_.isEqual(val, oldVal)) {
       this.stepSelectedColumn = val[0];
     }
   }

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -46,9 +46,7 @@ describe('Action Menu', () => {
       actionsWrapper.at(1).trigger('click');
 
       expect(wrapper.emitted().actionClicked).not.to.be.empty;
-      expect(wrapper.emitted().actionClicked[0]).to.eql([
-        { name: 'rename', oldname: 'dreamfall', newname: '' },
-      ]);
+      expect(wrapper.emitted().actionClicked[0]).to.eql(['rename']);
     });
 
     it('should emit a close event', () => {
@@ -104,9 +102,7 @@ describe('Action Menu', () => {
       const actionsWrapper = wrapper.findAll('.action-menu__option');
       actionsWrapper.at(3).trigger('click');
 
-      expect(wrapper.emitted().actionClicked[0]).to.eql([
-        { name: 'fillna', column: 'dreamfall', value: '' },
-      ]);
+      expect(wrapper.emitted().actionClicked[0]).to.eql(['fillna']);
     });
   });
 

--- a/tests/unit/action-toolbar.spec.ts
+++ b/tests/unit/action-toolbar.spec.ts
@@ -103,8 +103,6 @@ describe('ActionToolbar', () => {
     buttons.at(0).trigger('click');
     expect(wrapper.emitted().actionClicked).not.to.exist;
     buttons.at(1).trigger('click');
-    expect(wrapper.emitted().actionClicked[0]).to.eql([
-      { name: 'aggregate', on: [], aggregations: [] },
-    ]);
+    expect(wrapper.emitted().actionClicked[0]).to.eql(['aggregate']);
   });
 });

--- a/tests/unit/vqb.spec.ts
+++ b/tests/unit/vqb.spec.ts
@@ -85,9 +85,7 @@ describe('Vqb', () => {
     const store = setupStore();
     const wrapper = shallowMount(Vqb, { store, localVue });
     expect(store.state.isEditingStep).to.be.false;
-    wrapper
-      .find('dataviewer-stub')
-      .vm.$emit('stepCreated', { name: 'rename', oldname: 'foo', newname: 'bar' });
+    wrapper.find('dataviewer-stub').vm.$emit('stepCreated', 'rename');
     await wrapper.vm.$nextTick();
     expect(store.state.isEditingStep).to.be.true;
   });
@@ -178,9 +176,7 @@ describe('Vqb', () => {
   it('should keep editingMode on when trying to creating a step while a form is already open', async () => {
     const store = setupStore({ isEditingStep: true });
     const wrapper = shallowMount(Vqb, { store, localVue });
-    wrapper
-      .find('dataviewer-stub')
-      .vm.$emit('stepCreated', { name: 'rename', oldname: 'foo', newname: 'bar' });
+    wrapper.find('dataviewer-stub').vm.$emit('stepCreated', 'rename');
     await wrapper.vm.$nextTick();
     expect(store.state.isEditingStep).to.be.true;
   });


### PR DESCRIPTION
In order to avoid writting special case for each steps. To do so, we now open form base on their names. The default case is defined in all forms and properties that we want to link to `selectedColumns` has already the logic to update itself when the getters was modified, I just add the fact is also done at the mounted cycle too.