### PR TITLE
Fix :: Remove stepSelectedColumn getter and setter in AggregateStepForm

### DIFF
--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -23,7 +23,6 @@
 </template>
 
 <script lang="ts">
-import _ from 'lodash';
 import { Prop } from 'vue-property-decorator';
 import { AggFunctionStep, AggregationStep } from '@/lib/steps';
 import aggregateSchema from '@/assets/schemas/aggregate-step__schema.json';
@@ -67,19 +66,6 @@ export default class AggregateStepForm extends BaseStepForm<AggregationStep> {
 
   set aggregations(newval) {
     this.editedStep.aggregations = [...newval];
-  }
-
-  get stepSelectedColumn() {
-    return this.editedStep.on[this.editedStep.on.length - 1];
-  }
-
-  set stepSelectedColumn(colname: string | null) {
-    if (colname === null) {
-      throw new Error('should not try to set null on filter "column" field');
-    }
-    if (!_.isNil(colname) && !this.editedStep.on.includes(colname)) {
-      this.editedStep.on.push(colname);
-    }
   }
 
   submit() {


### PR DESCRIPTION
The stepSelectedColumn getter and setter functions were designed to manage some interactions with the table but had side effects.
We prefer no interaction rather than bad. I think that this interaction matter deserves a specific PR. In the meantime, forms work very well (or even better) without them !

**Exemple of issue:**

Context:

- An aggregate step has already been created in the pipeline and we want to modify it.
- A column which is not in the group by (`on`) parameter of the aggregate step form, is focused in the dataset

When clicking on edit: the focused column gets added to `editedStep.on` on opening.
When clicking on cancel: it does not cancel the undesired change (editedStep.on has been muted and cancel has the same effect as submit => there may be an issue to tackle in our BaseStepForm ?)
