### PR TITLE
Feature :: Infer type of DataSetColumn

### DIFF
--- a/src/components/DataViewer.vue
+++ b/src/components/DataViewer.vue
@@ -11,6 +11,11 @@
               :key="column.name"
               @click="toggleColumnSelection({ column: column.name})"
             >
+              <span
+                v-if="column.type"
+                v-html="getIconType(column.type)"
+                class="data-viewer__header-icon"
+              ></span>
               <span class="data-viewer__header-label">{{ column.name }}</span>
               <i
                 class="data-viewer__header-action fas fa-angle-down"
@@ -32,7 +37,7 @@
             <DataViewerCell
               v-for="(cell, cellidx) in row"
               :key="cellidx"
-              :isSelected="isSelected(columnNames[cellidx])"
+              :isSelected="isSelected(columnHeaders[cellidx].name)"
               :value="cell"
             />
           </tr>
@@ -46,7 +51,7 @@
 import Vue from 'vue';
 import { Getter, Mutation, State } from 'vuex-class';
 
-import { DataSet } from '@/lib/dataset';
+import { DataSet, DataSetColumn, DataSetColumnType } from '@/lib/dataset';
 import { PipelineStepName } from '@/lib/steps';
 import { Component } from 'vue-property-decorator';
 import ActionMenu from './ActionMenu.vue';
@@ -72,7 +77,7 @@ export default class DataViewer extends Vue {
   @State selectedColumns!: string[];
 
   @Getter('isDatasetEmpty') isEmpty!: boolean;
-  @Getter columnNames!: string[];
+  @Getter columnHeaders!: DataSetColumn[];
 
   @Mutation toggleColumnSelection!: ({ column }: { column: string }) => void;
   @Mutation setSelectedColumns!: ({ column }: { column: string }) => void;
@@ -85,7 +90,7 @@ export default class DataViewer extends Vue {
    * @return {Array<object>}
    */
   get formattedColumns() {
-    return this.columnNames.map((d, index) => {
+    return this.columnHeaders.map((d, index) => {
       let isActionMenuOpened = false;
 
       if (index === this.indexActiveActionMenu) {
@@ -93,11 +98,12 @@ export default class DataViewer extends Vue {
       }
 
       return {
-        name: d,
+        name: d.name,
+        type: d.type || undefined,
         isActionMenuOpened,
         class: {
           'data-viewer__header-cell': true,
-          'data-viewer__header-cell--active': this.isSelected(d),
+          'data-viewer__header-cell--active': this.isSelected(d.name),
         },
       };
     });
@@ -115,6 +121,23 @@ export default class DataViewer extends Vue {
    */
   isSelected(column: string) {
     return this.selectedColumns.includes(column);
+  }
+
+  getIconType(type: DataSetColumnType) {
+    switch (type) {
+      case 'string':
+        return 'ABC';
+      case 'integer':
+        return '123';
+      case 'float':
+        return '1.2';
+      case 'date':
+        return '<i class="fas fa-calendar-alt"></i>';
+      case 'boolean':
+        return '<i class="fas fa-check"></i>';
+      case 'object':
+        return '{ }';
+    }
   }
 
   openMenu(index: number) {

--- a/src/lib/dataset/index.ts
+++ b/src/lib/dataset/index.ts
@@ -2,9 +2,11 @@
  * This module contains helpers and definitions related to datasets.
  */
 
+export type DataSetColumnType = 'integer' | 'float' | 'boolean' | 'string' | 'date' | 'object';
+
 export type DataSetColumn = {
   name: string;
-  type?: 'integer' | 'float' | 'boolean' | 'string' | 'date' | 'object';
+  type?: DataSetColumnType;
 };
 
 /**

--- a/src/lib/dataset/mongo.ts
+++ b/src/lib/dataset/mongo.ts
@@ -2,7 +2,7 @@
  * mongo specific helpers for dataset manipulation.
  */
 
-import { DataSet } from '@/lib/dataset';
+import { DataSet, DataSetColumn, DataSetColumnType } from '@/lib/dataset';
 
 type MongoDocument = { [k: string]: any };
 export type MongoResults = MongoDocument[];
@@ -15,11 +15,11 @@ export function mongoResultsToDataset(results: MongoResults): DataSet {
   const dataset: DataSet = { headers: [], data: [] };
   if (results.length) {
     const colnames = results
-    // get list of list of key
+      // get list of list of key
       .map(row => Object.keys(row))
-    // then flatten them
+      // then flatten them
       .flat()
-    // and remove duplicates by keeping the _first_ occurence
+      // and remove duplicates by keeping the _first_ occurence
       .filter((col, colidx, array) => array.indexOf(col) === colidx);
     // transform set of names to list of DataSetColumn objects
     dataset.headers = colnames.map(name => ({ name }));
@@ -30,4 +30,40 @@ export function mongoResultsToDataset(results: MongoResults): DataSet {
     }
   }
   return dataset;
+}
+
+function _isSupportedType(val: any): val is DataSetColumnType {
+  return val !== 'undefined' && val !== 'symbol' && val !== 'function';
+}
+
+function _isNumber(val: any): val is 'number' {
+  return val === 'number' || val === 'bigint';
+}
+
+function _isInt(val: any) {
+  return Number(val) === val && val % 1 === 0;
+}
+
+function _isFloat(val: any) {
+  return Number(val) === val && val % 1 !== 0;
+}
+
+export function _guessType(val: any, prevType: any = null): DataSetColumnType | null {
+  const type = typeof val;
+
+  if (val === null) {
+    return prevType;
+  } else if (_isNumber(type)) {
+    if (_isInt(val)) {
+      return 'integer';
+    } else if (_isFloat(val)) {
+      return 'float';
+    }
+  } else if (type === 'object' && val instanceof Date) {
+    return 'date';
+  } else if (_isSupportedType(type) && val !== null) {
+    return type;
+  }
+
+  return null;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 // export lib entrypoints
 export { filterOutDomain, mongoToPipe } from './lib/pipeline';
 export { getTranslator } from './lib/translators';
-export { mongoResultsToDataset } from './lib/dataset/mongo';
+export { mongoResultsToDataset, inferTypeFromDataset } from './lib/dataset/mongo';
 
 // export store entrypoints
 export { servicePluginFactory } from '@/store/backend-plugin';

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -14,6 +14,10 @@ export default {
    **/
   columnNames: (state: VQBState) => state.dataset.headers.map(col => col.name),
   /**
+   * the list of dataset's column headers.
+   */
+  columnHeaders: (state: VQBState) => state.dataset.headers,
+  /**
    * a direct "usable" index (i.e. convert "-1" to a positive one) of last active step.
    */
   computedActiveStepIndex: (state: VQBState) =>

--- a/src/styles/DataViewer.scss
+++ b/src/styles/DataViewer.scss
@@ -49,7 +49,7 @@
 
 .data-viewer__header-cell {
   font-weight: bold;
-  padding: 6px 8px 3px;
+  padding: 6px 8px;
 }
 
 .data-viewer__header-cell--active {
@@ -64,14 +64,23 @@
   .data-viewer__header-action:hover {
     background-color: $active-color-faded-2;
   }
+
+  .data-viewer__header-icon {
+    color: $active-color-faded;
+  }
 }
 
 .data-viewer__header-label {
-  display: inline-block;
   text-overflow: ellipsis;
   max-width: 200px;
   overflow: hidden;
-  padding-right: 15px;
+  padding-right: 23px;
+}
+
+.data-viewer__header-icon {
+  font-family: 'Roboto Slab', serif;
+  color: #aaaaaa;
+  margin-right: 6px;
 }
 
 .data-viewer__header-action {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,6 +1,7 @@
 //FONT - Temporary declaration for montserrat google font.
 // => we have to decide if we will use the same font as used in Tucana
 @import url('https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Roboto+Slab:400&display=swap');
 
 // COLOR VARIABLES
 $base-color: #404040 !default;

--- a/tests/unit/data-viewer.spec.ts
+++ b/tests/unit/data-viewer.spec.ts
@@ -107,6 +107,42 @@ describe('Data Viewer', () => {
       expect(headerCellsWrapper.at(3).text()).to.equal('columnD');
     });
 
+    it('should display the right icon for each types', () => {
+      const date = new Date();
+      const store = setupStore({
+        dataset: {
+          headers: [
+            { name: 'columnA', type: 'string' },
+            { name: 'columnB', type: 'integer' },
+            { name: 'columnC', type: 'float' },
+            { name: 'columnD', type: 'date' },
+            { name: 'columnE', type: 'object' },
+            { name: 'columnF', type: 'boolean' },
+          ],
+          data: [['value1', 42, 3.14, date, { obj: 'value' }, true]],
+        },
+      });
+      const wrapper = shallowMount(DataViewer, { store, localVue });
+
+      const headerIconsWrapper = wrapper.findAll('.data-viewer__header-icon');
+      expect(headerIconsWrapper.at(0).text()).to.equal('ABC');
+      expect(headerIconsWrapper.at(1).text()).to.equal('123');
+      expect(headerIconsWrapper.at(2).text()).to.equal('1.2');
+      expect(
+        headerIconsWrapper
+          .at(3)
+          .find('i')
+          .classes(),
+      ).to.eql(['fas', 'fa-calendar-alt']);
+      expect(headerIconsWrapper.at(4).text()).to.equal('{ }');
+      expect(
+        headerIconsWrapper
+          .at(5)
+          .find('i')
+          .classes(),
+      ).to.eql(['fas', 'fa-check']);
+    });
+
     describe('selection', () => {
       it('should add an active class on the cell', async () => {
         const store = setupStore({

--- a/tests/unit/dataset.spec.ts
+++ b/tests/unit/dataset.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { DataSet } from '@/lib/dataset';
-import { mongoResultsToDataset, MongoResults } from '@/lib/dataset/mongo';
+import { mongoResultsToDataset, MongoResults, _guessType } from '@/lib/dataset/mongo';
 
 /**
  * helper functions to sort a dataset so that we can test output in a predictible way.
@@ -81,5 +81,57 @@ describe('Dataset helper tests', () => {
       { name: 'col4' },
     ]);
     expect(dataset.data).to.eql([['foo', null, true, null], ['bar', 7, null, '?']]);
+  });
+});
+
+describe('_guessType', () => {
+  it('should return float', () => {
+    const val = _guessType(42.34);
+    expect(val).to.equal('float');
+  });
+
+  it('should return integer', () => {
+    const val = _guessType(42);
+    expect(val).to.equal('integer');
+  });
+
+  it('should return string', () => {
+    const val = _guessType('value');
+    expect(val).to.equal('string');
+  });
+
+  it('should return boolean', () => {
+    const val = _guessType(false);
+    expect(val).to.equal('boolean');
+  });
+
+  it('should return date', () => {
+    const val = _guessType(new Date());
+    expect(val).to.equal('date');
+  });
+
+  it('should return object', () => {
+    const val = _guessType({ value: 'my_value' });
+    expect(val).to.equal('object');
+  });
+
+  it('should return null when value is null', () => {
+    const val = _guessType(null);
+    expect(val).to.eql(null);
+  });
+
+  it('should return null when value is undefined', () => {
+    const val = _guessType(undefined);
+    expect(val).to.eql(null);
+  });
+
+  it('should return null when value is Symbol', () => {
+    const val = _guessType(Symbol());
+    expect(val).to.eql(null);
+  });
+
+  it('should return null when value is function', () => {
+    const val = _guessType(() => {});
+    expect(val).to.eql(null);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "esModuleInterop": true,
+    "downlevelIteration": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "baseUrl": ".",


### PR DESCRIPTION
In order to eventually implement `cast` step and improve the steps suggestions in our ActionToolbar, we implement a function that guess type of columns according a nb of first rows. Of course, others backend can provide us the types directly but if it's not the case, we've got this little alternative.

That closes #237 

Now
<img width="1376" alt="Capture d’écran 2019-07-05 à 17 12 37" src="https://user-images.githubusercontent.com/4061263/60731545-1f1d8200-9f48-11e9-9e2c-2c5f2aef9517.png">
