### PR TITLE
[column-picker] fix default export name

### DIFF
--- a/src/components/stepforms/ColumnPicker.vue
+++ b/src/components/stepforms/ColumnPicker.vue
@@ -18,7 +18,7 @@ import { Getter, Mutation } from 'vuex-class';
 import { MutationCallbacks } from '@/store/mutations';
 
 @Component({ components: { WidgetAutocomplete } })
-export default class DeletStepForm extends Vue {
+export default class ColumnPicker extends Vue {
   @Prop({ type: String, default: 'columnInput' })
   id!: string;
 


### PR DESCRIPTION
This has no impact feature-wise but fixing names is always a good
idea and it will help debugging in Vue-developer-tools