### PR TITLE
Fix :: rename step submit function

### DIFF
--- a/src/components/stepforms/RenameStepForm.vue
+++ b/src/components/stepforms/RenameStepForm.vue
@@ -54,7 +54,9 @@ export default class RenameStepForm extends BaseStepForm<RenameStep> {
 
   submit() {
     this.$$super.submit();
-    this.setSelectedColumns({ column: this.editedStep.newname });
+    if (this.errors === null) {
+      this.setSelectedColumns({ column: this.editedStep.newname });
+    }
   }
 }
 </script>

--- a/tests/unit/rename-step-form.spec.ts
+++ b/tests/unit/rename-step-form.spec.ts
@@ -153,4 +153,18 @@ describe('Rename Step Form', () => {
     wrapper.find('.widget-form-action__button--validate').trigger('click');
     expect(store.state.selectedColumns).to.eql(['toto']);
   });
+
+  it('should not change the column focus if validation fails', () => {
+    const store = setupStore({
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+      selectedColumns: ['columnA'],
+    });
+    const wrapper = mount(RenameStepForm, { store, localVue });
+    wrapper.setData({ editedStep: { name: 'rename', oldname: 'columnA', newname: 'columnB' } });
+    wrapper.find('.widget-form-action__button--validate').trigger('click');
+    expect(store.state.selectedColumns).to.eql(['columnA']);
+  });
 });


### PR DESCRIPTION
Do not change the column focus if validation fails on submit.

Before that PR, if an already existing column name was trying to be set as new column name, the validation failed as expected but the mutation setSelectedColumn was executed, so that it also changed the value of the columnPicker field (column to rename), which was not desired.