### PR TITLE
Infer types :: Infer float type when a column has a mix of integers and floats

### DIFF
--- a/src/lib/dataset/mongo.ts
+++ b/src/lib/dataset/mongo.ts
@@ -89,8 +89,14 @@ export function inferTypeFromDataset(dataset: DataSet, maxRows: number = 50): Da
       if (prevType === null) {
         prevType = guessedType;
       } else if (prevType !== guessedType) {
-        prevType = null;
-        break;
+        // if integers and floats are mixed, guessed type should be 'float'
+        const typeSet = new Set([prevType, guessedType]);
+        if (typeSet.has('integer') && typeSet.has('float')) {
+          prevType = 'float';
+        } else {
+          prevType = null;
+          break;
+        }
       }
     }
 

--- a/tests/unit/dataset.spec.ts
+++ b/tests/unit/dataset.spec.ts
@@ -277,4 +277,18 @@ describe('inferTypeFromDataset', () => {
       { name: 'isCapitalCity' },
     ]);
   });
+
+  it('should not infer a float type for mixed integer and float values', () => {
+    const dataset: DataSet = {
+      headers: [{ name: 'city' }, { name: 'density' }, { name: 'isCapitalCity' }],
+      data: [['Paris', 61.7, true], ['Marseille', 40, false], ['Berlin', 41.5, true]],
+    };
+
+    const datasetWithInferredType = inferTypeFromDataset(dataset);
+    expect(datasetWithInferredType.headers).to.eql([
+      { name: 'city', type: 'string' },
+      { name: 'density', type: 'float' },
+      { name: 'isCapitalCity', type: 'boolean' },
+    ]);
+  });
 });


### PR DESCRIPTION
Before that PR, when in a column there were numbers of mixed types between integer and float, we would not infer any type. But as floats can include integers, we are better off inferring a float type in such cases.