### PR TITLE
Fix WidgetAggregation :: Watch 'aggregation' data rather than 'value' prop

### DIFF
--- a/src/components/stepforms/WidgetAggregation.vue
+++ b/src/components/stepforms/WidgetAggregation.vue
@@ -23,12 +23,6 @@ import { Getter } from 'vuex-class';
 import { AggFunctionStep } from '@/lib/steps';
 import WidgetAutocomplete from './WidgetAutocomplete.vue';
 
-const defaultValues: AggFunctionStep = {
-  column: '',
-  aggfunction: 'sum',
-  newcolumn: '',
-};
-
 @Component({
   name: 'widget-aggregation',
   components: {
@@ -36,9 +30,7 @@ const defaultValues: AggFunctionStep = {
   },
 })
 export default class WidgetAggregation extends Vue {
-  @Prop({
-    type: Object,
-  })
+  @Prop({ type: Object, default: { column: '', aggfunction: 'sum', newcolumn: '' } })
   value!: AggFunctionStep;
 
   @Getter columnNames!: string[];
@@ -46,16 +38,9 @@ export default class WidgetAggregation extends Vue {
   aggregation: AggFunctionStep = { ...this.value };
   aggregationFunctions: AggFunctionStep['aggfunction'][] = ['sum', 'avg', 'count', 'min', 'max'];
 
-  created() {
-    if (_.isEmpty(this.value)) {
-      this.value = { ...defaultValues };
-    }
-  }
-
-  @Watch('value', { immediate: true, deep: true })
+  @Watch('aggregation', { immediate: true, deep: true })
   onAggregationChanged(newval: AggFunctionStep, oldval: AggFunctionStep) {
     if (!_.isEqual(newval, oldval)) {
-      this.aggregation = { ...newval };
       this.$emit('input', this.aggregation);
     }
   }

--- a/tests/unit/widget-aggregation.spec.ts
+++ b/tests/unit/widget-aggregation.spec.ts
@@ -37,28 +37,32 @@ describe('Widget WidgetAggregation', () => {
     expect(widgetWrappers.at(0).attributes('options')).to.equal('columnA,columnB,columnC');
   });
 
-  it('should pass down the "column" prop to the first WidgetAutocomplete value prop', async () => {
-    const wrapper = shallowMount(WidgetAggregation, { store: emptyStore, localVue });
-    wrapper.setProps({ value: { column: 'foo', newcolumn: '', aggfunction: 'sum' } });
-    await localVue.nextTick();
+  it('should pass down the "column" prop to the first WidgetAutocomplete value prop', () => {
+    const wrapper = shallowMount(WidgetAggregation, {
+      store: emptyStore,
+      localVue,
+      propsData: { value: { column: 'foo', newcolumn: '', aggfunction: 'sum' } },
+    });
     const widgetWrappers = wrapper.findAll('WidgetAutocomplete-stub');
     expect(widgetWrappers.at(0).props().value).to.eql('foo');
   });
 
-  it('should pass down the "aggfunction" prop to the second WidgetAutocomplete value prop', async () => {
-    const wrapper = shallowMount(WidgetAggregation, { store: emptyStore, localVue });
-    wrapper.setProps({ value: { column: 'foo', newcolumn: '', aggfunction: 'avg' } });
-    await localVue.nextTick();
+  it('should pass down the "aggfunction" prop to the second WidgetAutocomplete value prop', () => {
+    const wrapper = shallowMount(WidgetAggregation, {
+      store: emptyStore,
+      localVue,
+      propsData: { value: { column: 'foo', newcolumn: '', aggfunction: 'avg' } },
+    });
     const widgetWrappers = wrapper.findAll('WidgetAutocomplete-stub');
     expect(widgetWrappers.at(1).props().value).to.eql('avg');
   });
 
-  it('should emit "input" event on "value" update', async () => {
+  it('should emit "input" event on "aggregation" update', async () => {
     const wrapper = shallowMount(WidgetAggregation, {
       store: emptyStore,
       localVue,
     });
-    wrapper.setProps({ value: { column: 'bar', newcolumn: '', aggfunction: 'avg' } });
+    wrapper.setData({ aggregation: { column: 'bar', newcolumn: '', aggfunction: 'avg' } });
     await localVue.nextTick();
     expect(wrapper.emitted().input).to.exist;
     expect(wrapper.emitted().input[0]).to.eql([


### PR DESCRIPTION
The previous code worked but in a roundabout way:

- `value` was set as `undefined` because no default was defined for this prop
- We copied the `value` prop in the `aggregation` data
- We watched a change in `value` to emit `aggregation` (weird already :))
- As such, `value` only changed once, at created (when switching from `undefined` to `defaultAggregation`)
- We therefore emitted `aggregation` at this first and only watched change
- At this stage, any subsequent change in `aggregation` impacted the parent only by reference and not by way of the watcher

So we propose here to clean the code to make it lighter:
- we set a valid default value for `value` prop directly through it decorator and not from a getter called at created
- we watch `aggregation` data rather than the `value` prop