### PR TITLE
Feature :: search bar with categories

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -14,8 +14,8 @@
   </div>
 </template>
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
-import { ActionCategory, SEARCH_ACTION } from './constants';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { groupActions, SEARCH_ACTION } from './constants';
 import Multiselect from 'vue-multiselect';
 
 @Component({
@@ -25,7 +25,7 @@ import Multiselect from 'vue-multiselect';
   },
 })
 export default class SearchBar extends Vue {
-  actionOptions: ActionCategory[] = SEARCH_ACTION;
+  actionOptions: groupActions[] = SEARCH_ACTION;
 
   actionClicked(actionName: { name: string }) {
     this.$emit('actionClicked', actionName.name);
@@ -105,6 +105,9 @@ export default class SearchBar extends Vue {
 .search-bar .multiselect__option {
   color: $base-color;
   font-size: 12px;
+  padding: 10px 10px 10px 15px;
+  box-shadow: none;
+  min-height: 0;
   &:focus {
     outline: none;
   }
@@ -112,10 +115,15 @@ export default class SearchBar extends Vue {
 .search-bar .multiselect__option--group {
   background: none !important;
   color: $base-color !important;
+  border-top: 1px solid #e0e0e0;
   font-weight: bold;
   box-shadow: none;
-  min-height: 35px;
+  min-height: 30px;
   padding-bottom: 0;
+  padding-left: 12px;
   text-transform: capitalize;
+}
+.search-bar .multiselect__element:first-child .multiselect__option--group {
+  border: 0;
 }
 </style>

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -6,6 +6,9 @@
       track-by="label"
       :placeholder="'Search'"
       :reset-after="true"
+      group-label="type"
+      group-values="actions"
+      :group-select="false"
       @select="actionClicked"
     ></multiselect>
   </div>
@@ -105,5 +108,14 @@ export default class SearchBar extends Vue {
   &:focus {
     outline: none;
   }
+}
+.search-bar .multiselect__option--group {
+  background: none !important;
+  color: $base-color !important;
+  font-weight: bold;
+  box-shadow: none;
+  min-height: 35px;
+  padding-bottom: 0;
+  text-transform: capitalize;
 }
 </style>

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -17,6 +17,11 @@ export type ActionCategory = {
   label: string;
 };
 
+export type groupActions = {
+  type: string;
+  actions: ActionCategory[];
+};
+
 export const ACTION_CATEGORIES: ActionCategories = {
   compute: [{ name: 'percentage', label: 'Percentage of total' }],
   filter: [
@@ -30,7 +35,7 @@ export const ACTION_CATEGORIES: ActionCategories = {
   reshape: [{ name: 'pivot', label: 'Pivot' }, { name: 'unpivot', label: 'Unpivot' }],
 };
 
-export const SEARCH_ACTION: ActionCategory[] = [
+export const SEARCH_ACTION: groupActions[] = [
   {
     type: 'compute',
     actions: [{ name: 'percentage', label: 'Percentage of total' }],
@@ -55,7 +60,6 @@ export const SEARCH_ACTION: ActionCategory[] = [
       { name: 'filter', label: 'Filter values' },
     ],
   },
-  { name: 'aggregate', label: 'Aggregate' },
   {
     type: 'aggregate',
     actions: [

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -31,20 +31,44 @@ export const ACTION_CATEGORIES: ActionCategories = {
 };
 
 export const SEARCH_ACTION: ActionCategory[] = [
+  {
+    type: 'compute',
+    actions: [{ name: 'percentage', label: 'Percentage of total' }],
+  },
+  {
+    type: 'filter',
+    actions: [
+      { name: 'delete', label: 'Delete columns' },
+      { name: 'select', label: 'Keep columns' },
+      { name: 'filter', label: 'Filter based on conditions' },
+      { name: 'top', label: 'Top N rows' },
+      { name: 'argmax', label: 'Argmax' },
+      { name: 'argmin', label: 'Argmin' },
+    ],
+  },
+  {
+    type: 'head Column action',
+    actions: [
+      { name: 'duplicate', label: 'Duplicate column' },
+      { name: 'rename', label: 'Rename column' },
+      { name: 'fillna', label: 'Fill null values' },
+      { name: 'filter', label: 'Filter values' },
+    ],
+  },
   { name: 'aggregate', label: 'Aggregate' },
-  { name: 'percentage', label: 'Percentage of total' },
-  { name: 'delete', label: 'Delete columns' },
-  { name: 'select', label: 'Keep columns' },
-  { name: 'filter', label: 'Filter based on conditions' },
-  { name: 'top', label: 'Top N rows' },
-  { name: 'argmax', label: 'Argmax' },
-  { name: 'argmin', label: 'Argmin' },
-  { name: 'pivot', label: 'Pivot' },
-  { name: 'unpivot', label: 'Unpivot' },
-  { name: 'duplicate', label: 'Duplicate column' },
-  { name: 'rename', label: 'Rename column' },
-  { name: 'fillna', label: 'Fill null values' },
-  { name: 'filter', label: 'Filter values' },
+  {
+    type: 'aggregate',
+    actions: [
+      {
+        name: 'aggregate',
+        label: 'Aggregate',
+      },
+    ],
+  },
+  {
+    type: 'reshape',
+    actions: [{ name: 'pivot', label: 'Pivot' }, { name: 'unpivot', label: 'Unpivot' }],
+  },
 ];
 
 export const CATEGORY_BUTTONS: ButtonDef[] = [

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -52,15 +52,6 @@ export const SEARCH_ACTION: groupActions[] = [
     ],
   },
   {
-    type: 'head Column action',
-    actions: [
-      { name: 'duplicate', label: 'Duplicate column' },
-      { name: 'rename', label: 'Rename column' },
-      { name: 'fillna', label: 'Fill null values' },
-      { name: 'filter', label: 'Filter values' },
-    ],
-  },
-  {
     type: 'aggregate',
     actions: [
       {
@@ -72,6 +63,15 @@ export const SEARCH_ACTION: groupActions[] = [
   {
     type: 'reshape',
     actions: [{ name: 'pivot', label: 'Pivot' }, { name: 'unpivot', label: 'Unpivot' }],
+  },
+  {
+    type: 'Others action',
+    actions: [
+      { name: 'duplicate', label: 'Duplicate column' },
+      { name: 'rename', label: 'Rename column' },
+      { name: 'fillna', label: 'Fill null values' },
+      { name: 'filter', label: 'Filter values' },
+    ],
   },
 ];
 

--- a/tests/unit/search-bar.spec.ts
+++ b/tests/unit/search-bar.spec.ts
@@ -15,19 +15,17 @@ describe('SearchBar', () => {
   it('should display the right option into multiselect', () => {
     const wrapper = mount(SearchBar, {
       propsData: {
-        actionOptions: [
-          { name: 'aggregate', label: 'Aggregate' },
-          { name: 'select', label: 'Keep columns' },
-        ],
+        type: 'compute',
+        actions: [{ name: 'percentage', label: 'Percentage of total' }],
       },
     });
     const multiselect = wrapper.findAll('.multiselect__option');
     expect(
       multiselect
-        .at(0)
+        .at(1)
         .find('span span')
         .text(),
-    ).toEqual('Aggregate');
+    ).to.equal('Percentage of total');
   });
 
   it('should emit "actionClicked" when an option multiselect is clicked', () => {

--- a/tests/unit/search-bar.spec.ts
+++ b/tests/unit/search-bar.spec.ts
@@ -25,7 +25,7 @@ describe('SearchBar', () => {
         .at(1)
         .find('span span')
         .text(),
-    ).to.equal('Percentage of total');
+    ).toEqual('Percentage of total');
   });
 
   it('should emit "actionClicked" when an option multiselect is clicked', () => {


### PR DESCRIPTION
Improvement of search bar, now it's organized by categories.
Vue multiselect doesn't allow you to customize a lot the group options so I try to do something not too ugly with it :

~~I put the label "wip" but if you're ok with this PR we can merge it for the V1 of VQB~~
=> After discussion it will be ok for the V1

@vdestraitt  Edit new version after your feedbacks :
![image](https://user-images.githubusercontent.com/4438175/62382112-33579d80-b54d-11e9-9f94-85c089a01efc.png)
