### PR TITLE
[store] introduce a `pagesize` state property

### DIFF
--- a/src/store/backend-plugin.ts
+++ b/src/store/backend-plugin.ts
@@ -22,14 +22,18 @@ export interface BackendService {
   listCollections(): Promise<string[]>;
   /**
    * @param pipeline the pipeline to translate and execute on the backend
+   * @param limit if specified, a limit to be applied on the results. How is limit
+   * is applied is up to the concrete implementor (either in the toolchain, the query
+   * or afterwareds on the resultset)
+   *
    * @return a promise that holds the result of the pipeline execution,
    * formatted as as `DataSet`
    */
-  executePipeline(pipeline: Pipeline): Promise<DataSet>;
+  executePipeline(pipeline: Pipeline, limit: number): Promise<DataSet>;
 }
 
 async function _updateDataset(store: Store<VQBState>, service: BackendService, pipeline: Pipeline) {
-  const dataset = await service.executePipeline(pipeline);
+  const dataset = await service.executePipeline(pipeline, store.state.pagesize);
   store.commit('setDataset', { dataset });
 }
 

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -35,6 +35,11 @@ export interface VQBState {
    * whether the left panel slot is in step edition mode
    */
   isEditingStep: boolean;
+
+  /**
+   * pagination size (i.e. number of results displayed)
+   */
+  pagesize: number;
 }
 
 /**
@@ -51,6 +56,7 @@ export const emptyState: VQBState = {
   pipeline: [],
   selectedColumns: [],
   isEditingStep: false,
+  pagesize: 50,
 };
 
 /**

--- a/tests/unit/plugins.spec.ts
+++ b/tests/unit/plugins.spec.ts
@@ -17,10 +17,14 @@ class DummyService implements BackendService {
   }
 
   // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-  executePipeline(pipeline: Pipeline) {
+  executePipeline(pipeline: Pipeline, limit: number) {
+    let rset = [[1, 2], [3, 4]];
+    if (limit) {
+      rset = rset.slice(0, limit);
+    }
     return Promise.resolve({
       headers: [{ name: 'x' }, { name: 'y' }],
-      data: [[1, 2], [3, 4]],
+      data: rset,
     });
   }
 }
@@ -81,6 +85,16 @@ describe('backend service plugin tests', () => {
     expect(store.state.dataset).toEqual({
       headers: [{ name: 'x' }, { name: 'y' }],
       data: [[1, 2], [3, 4]],
+    });
+  });
+
+  it('should call execute pipeline with correct pagesize', async () => {
+    const store = setupStore({ pagesize: 1 }, [servicePluginFactory(new DummyService())]);
+    store.commit('setCurrentDomain', { currentDomain: 'GoT' });
+    await flushPromises();
+    expect(store.state.dataset).toEqual({
+      headers: [{ name: 'x' }, { name: 'y' }],
+      data: [[1, 2]],
     });
   });
 });


### PR DESCRIPTION
`pagesize` will set the number of elements that should be displayed on
a single page of the dataviewer. Since there is no real pagination for now,
this is a just a simple limit