### PR TITLE
fix widget modules naming

### DIFF
--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -1,15 +1,15 @@
 <template>
   <div>
     <step-form-title :title="title"></step-form-title>
-    <WidgetMultiselect
+    <MultiselectWidget
       id="groupbyColumnsInput"
       v-model="editedStep.on"
       name="Group rows by..."
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.on[editedStep.on.length-1] })"
       placeholder="Add columns"
-    ></WidgetMultiselect>
-    <WidgetList
+    ></MultiselectWidget>
+    <ListWidget
       addFieldName="Add aggregation"
       id="toremove"
       name="And aggregate..."
@@ -17,7 +17,7 @@
       :defaultItem="defaultAggregation"
       :widget="widgetAggregation"
       :automatic-new-field="false"
-    ></WidgetList>
+    ></ListWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -25,9 +25,9 @@
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
 import { AggFunctionStep, AggregationStep } from '@/lib/steps';
-import WidgetAggregation from './WidgetAggregation.vue';
-import WidgetMultiselect from './WidgetMultiselect.vue';
-import WidgetList from './WidgetList.vue';
+import AggregationWidget from './widgets/Aggregation.vue';
+import MultiselectWidget from './widgets/Multiselect.vue';
+import ListWidget from './widgets/List.vue';
 import BaseStepForm from './StepForm.vue';
 import { StepFormComponent } from '@/components/formlib';
 
@@ -35,8 +35,8 @@ import { StepFormComponent } from '@/components/formlib';
   vqbstep: 'aggregate',
   name: 'aggregate-step-form',
   components: {
-    WidgetList,
-    WidgetMultiselect,
+    ListWidget,
+    MultiselectWidget,
   },
 })
 export default class AggregateStepForm extends BaseStepForm<AggregationStep> {
@@ -44,7 +44,7 @@ export default class AggregateStepForm extends BaseStepForm<AggregationStep> {
   initialStepValue!: AggregationStep;
 
   readonly title: string = 'Aggregate';
-  widgetAggregation = WidgetAggregation;
+  widgetAggregation = AggregationWidget;
 
   get defaultAggregation() {
     const agg: AggFunctionStep = {

--- a/src/components/stepforms/ArgmaxStepForm.vue
+++ b/src/components/stepforms/ArgmaxStepForm.vue
@@ -7,14 +7,14 @@
       name="Search min value in..."
       placeholder="Enter a column name"
     ></ColumnPicker>
-    <WidgetMultiselect
+    <MultiselectWidget
       id="groupbyColumnsInput"
       v-model="editedStep.groups"
       name="(Optional) Group by..."
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.groups[editedStep.groups.length-1] })"
       placeholder="Add columns"
-    ></WidgetMultiselect>
+    ></MultiselectWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -23,7 +23,7 @@
 import { Prop } from 'vue-property-decorator';
 import { ArgmaxStep } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import WidgetMultiselect from './WidgetMultiselect.vue';
+import MultiselectWidget from './widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
 import { StepFormComponent } from '@/components/formlib';
 
@@ -32,7 +32,7 @@ import { StepFormComponent } from '@/components/formlib';
   name: 'argmax-step-form',
   components: {
     ColumnPicker,
-    WidgetMultiselect,
+    MultiselectWidget,
   },
 })
 export default class ArgmaxStepForm extends BaseStepForm<ArgmaxStep> {

--- a/src/components/stepforms/ArgminStepForm.vue
+++ b/src/components/stepforms/ArgminStepForm.vue
@@ -7,14 +7,14 @@
       name="Search min value in..."
       placeholder="Enter a column name"
     ></ColumnPicker>
-    <WidgetMultiselect
+    <MultiselectWidget
       id="groupbyColumnsInput"
       v-model="editedStep.groups"
       name="(Optional) Group by..."
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.groups[editedStep.groups.length-1] })"
       placeholder="Add columns"
-    ></WidgetMultiselect>
+    ></MultiselectWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -23,7 +23,7 @@
 import { Prop } from 'vue-property-decorator';
 import { ArgminStep } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import WidgetMultiselect from './WidgetMultiselect.vue';
+import MultiselectWidget from './widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
 import { StepFormComponent } from '@/components/formlib';
 
@@ -32,7 +32,7 @@ import { StepFormComponent } from '@/components/formlib';
   name: 'argmin-step-form',
   components: {
     ColumnPicker,
-    WidgetMultiselect,
+    MultiselectWidget,
   },
 })
 export default class ArgminStepForm extends BaseStepForm<ArgminStep> {

--- a/src/components/stepforms/ColumnPicker.vue
+++ b/src/components/stepforms/ColumnPicker.vue
@@ -1,23 +1,23 @@
 <template>
-  <WidgetAutocomplete
+  <AutocompleteWidget
     id=":id"
     v-model="column"
     :name="name"
     :options="columnNames"
     @input="valueChanged"
     :placeholder="placeholder"
-  ></WidgetAutocomplete>
+  ></AutocompleteWidget>
 </template>
 
 <script lang="ts">
 import _ from 'lodash';
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
-import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
+import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import { Getter, Mutation } from 'vuex-class';
 import { MutationCallbacks } from '@/store/mutations';
 
-@Component({ components: { WidgetAutocomplete } })
+@Component({ components: { AutocompleteWidget } })
 export default class ColumnPicker extends Vue {
   @Prop({ type: String, default: 'columnInput' })
   id!: string;

--- a/src/components/stepforms/DeleteColumnStepForm.vue
+++ b/src/components/stepforms/DeleteColumnStepForm.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
     <step-form-title :title="title"></step-form-title>
-    <WidgetMultiselect
+    <MultiselectWidget
       id="columnsInput"
       v-model="editedStep.columns"
       name="Delete columns..."
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.columns[editedStep.columns.length-1] })"
       placeholder="Add columns"
-    ></WidgetMultiselect>
+    ></MultiselectWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -16,7 +16,7 @@
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
 import { StepFormComponent } from '@/components/formlib';
-import WidgetMultiselect from '@/components/stepforms/WidgetMultiselect.vue';
+import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
 import { DeleteStep } from '@/lib/steps';
 
@@ -24,7 +24,7 @@ import { DeleteStep } from '@/lib/steps';
   vqbstep: 'delete',
   name: 'delete-step-form',
   components: {
-    WidgetMultiselect,
+    MultiselectWidget,
   },
 })
 export default class DeleteStepForm extends BaseStepForm<DeleteStep> {

--- a/src/components/stepforms/DomainStepForm.vue
+++ b/src/components/stepforms/DomainStepForm.vue
@@ -1,20 +1,20 @@
 <template>
   <div>
     <step-form-title :title="title"></step-form-title>
-    <WidgetAutocomplete
+    <AutocompleteWidget
       id="domainInput"
       v-model="editedStep.domain"
       name="Select domain..."
       :options="domains"
       placeholder="Choose a domain"
-    ></WidgetAutocomplete>
+    ></AutocompleteWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
-import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
+import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import { State } from 'vuex-class';
 import { StepFormComponent } from '@/components/formlib';
 import BaseStepForm from './StepForm.vue';
@@ -24,7 +24,7 @@ import { DomainStep } from '@/lib/steps';
   vqbstep: 'domain',
   name: 'domain-step-form',
   components: {
-    WidgetAutocomplete,
+    AutocompleteWidget,
   },
 })
 export default class DomainStepForm extends BaseStepForm<DomainStep> {

--- a/src/components/stepforms/DuplicateColumnStepForm.vue
+++ b/src/components/stepforms/DuplicateColumnStepForm.vue
@@ -7,12 +7,12 @@
       name="Duplicate column..."
       placeholder="Enter a column"
     ></ColumnPicker>
-    <WidgetInputText
+    <InputTextWidget
       id="newColumnNameInput"
       v-model="editedStep.new_column_name"
       name="New column name:"
       placeholder="Enter a column name"
-    ></WidgetInputText>
+    ></InputTextWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -21,7 +21,7 @@
 import { Prop } from 'vue-property-decorator';
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import BaseStepForm from './StepForm.vue';
 import { DuplicateColumnStep } from '@/lib/steps';
 
@@ -30,7 +30,7 @@ import { DuplicateColumnStep } from '@/lib/steps';
   name: 'duplicate-step-form',
   components: {
     ColumnPicker,
-    WidgetInputText,
+    InputTextWidget,
   },
 })
 export default class DuplicateColumnForm extends BaseStepForm<DuplicateColumnStep> {

--- a/src/components/stepforms/FillnaStepForm.vue
+++ b/src/components/stepforms/FillnaStepForm.vue
@@ -7,12 +7,12 @@
       name="Replace null values in..."
       placeholder="Enter a column"
     ></ColumnPicker>
-    <WidgetInputText
+    <InputTextWidget
       id="valueInput"
       v-model="editedStep.value"
       name="With..."
       placeholder="Enter a value"
-    ></WidgetInputText>
+    ></InputTextWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -21,7 +21,7 @@
 import { Prop } from 'vue-property-decorator';
 import { Getter } from 'vuex-class';
 import { StepFormComponent } from '@/components/formlib';
-import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import BaseStepForm from './StepForm.vue';
 import { FillnaStep } from '@/lib/steps';
@@ -33,7 +33,7 @@ import { castFromString } from '@/lib/helpers';
   name: 'fillna-step-form',
   components: {
     ColumnPicker,
-    WidgetInputText,
+    InputTextWidget,
   },
 })
 export default class FillnaStepForm extends BaseStepForm<FillnaStep> {

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -5,14 +5,14 @@
       <div class="filter-form-header">Values in...</div>
       <div class="filter-form-header">Must...</div>
     </div>
-    <WidgetList
+    <ListWidget
       addFieldName="Add condition"
       id="filterConditions"
       v-model="conditions"
       :defaultItem="defaultCondition"
       :widget="widgetFilterSimpleCondition"
       :automatic-new-field="false"
-    ></WidgetList>
+    ></ListWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -20,8 +20,8 @@
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
 import { StepFormComponent } from '@/components/formlib';
-import WidgetFilterSimpleCondition from '@/components/stepforms/WidgetFilterSimpleCondition.vue';
-import WidgetList from './WidgetList.vue';
+import FilterSimpleConditionWidget from '@/components/stepforms/widgets/FilterSimpleCondition.vue';
+import ListWidget from './widgets/List.vue';
 import BaseStepForm from './StepForm.vue';
 import { FilterStep, FilterComboAnd } from '@/lib/steps';
 import { FilterSimpleCondition } from '@/lib/steps';
@@ -30,8 +30,8 @@ import { FilterSimpleCondition } from '@/lib/steps';
   vqbstep: 'filter',
   name: 'filter-step-form',
   components: {
-    WidgetFilterSimpleCondition,
-    WidgetList,
+    FilterSimpleConditionWidget,
+    ListWidget,
   },
 })
 export default class FilterStepForm extends BaseStepForm<FilterStep> {
@@ -47,7 +47,7 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
   readonly title: string = 'Filter';
   condition = this.initialStepValue.condition as FilterComboAnd;
   editedStep = { name: 'filter' as 'filter', condition: { ...this.condition } };
-  widgetFilterSimpleCondition = WidgetFilterSimpleCondition;
+  widgetFilterSimpleCondition = FilterSimpleConditionWidget;
 
   get defaultCondition() {
     const cond: FilterSimpleCondition = { column: '', value: '', operator: 'eq' };

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <step-form-title :title="title"></step-form-title>
-    <WidgetInputText id="formulaInput" v-model="editedStep.formula" name="Formula:" placeholder></WidgetInputText>
-    <WidgetInputText
+    <InputTextWidget id="formulaInput" v-model="editedStep.formula" name="Formula:" placeholder></InputTextWidget>
+    <InputTextWidget
       id="newColumnInput"
       v-model="editedStep.new_column"
       name="New colum:"
       placeholder="Enter a new column name"
-    ></WidgetInputText>
+    ></InputTextWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -15,7 +15,7 @@
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
 import { StepFormComponent } from '@/components/formlib';
-import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import BaseStepForm from './StepForm.vue';
 import { FormulaStep } from '@/lib/steps';
 import { parse } from 'mathjs';
@@ -27,7 +27,7 @@ type VqbError = Partial<ErrorObject>;
   vqbstep: 'formula',
   name: 'formula-step-form',
   components: {
-    WidgetInputText,
+    InputTextWidget,
   },
 })
 export default class FormulaStepForm extends BaseStepForm<FormulaStep> {

--- a/src/components/stepforms/PercentageStepForm.vue
+++ b/src/components/stepforms/PercentageStepForm.vue
@@ -7,20 +7,20 @@
       name="Value column..."
       placeholder="Enter a column"
     ></ColumnPicker>
-    <WidgetMultiselect
+    <MultiselectWidget
       id="groupbyColumnsInput"
       v-model="editedStep.group"
       name="(Optional) Group by..."
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.group[editedStep.group.length-1] })"
       placeholder="Add columns"
-    ></WidgetMultiselect>
-    <WidgetInputText
+    ></MultiselectWidget>
+    <InputTextWidget
       id="newColumnNameInput"
       v-model="editedStep.new_column"
       name="(Optional) New column name..."
       placeholder="Enter a new column name"
-    ></WidgetInputText>
+    ></InputTextWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -29,8 +29,8 @@
 import { Prop } from 'vue-property-decorator';
 import { PercentageStep } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import WidgetInputText from './WidgetInputText.vue';
-import WidgetMultiselect from './WidgetMultiselect.vue';
+import InputTextWidget from './widgets/InputText.vue';
+import MultiselectWidget from './widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
 import { StepFormComponent } from '@/components/formlib';
 
@@ -39,8 +39,8 @@ import { StepFormComponent } from '@/components/formlib';
   name: 'percentage-step-form',
   components: {
     ColumnPicker,
-    WidgetInputText,
-    WidgetMultiselect,
+    InputTextWidget,
+    MultiselectWidget,
   },
 })
 export default class PercentageStepForm extends BaseStepForm<PercentageStep> {

--- a/src/components/stepforms/PivotStepForm.vue
+++ b/src/components/stepforms/PivotStepForm.vue
@@ -1,33 +1,33 @@
 <template>
   <div>
     <step-form-title :title="title"></step-form-title>
-    <WidgetMultiselect
+    <MultiselectWidget
       id="indexInput"
       v-model="editedStep.index"
       name="Keep columns..."
       :options="columnNames"
       placeholder="Add columns"
-    ></WidgetMultiselect>
+    ></MultiselectWidget>
     <ColumnPicker
       id="columnToPivotInput"
       v-model="editedStep.column_to_pivot"
       name="Pivot column..."
       placeholder="Enter a column"
     ></ColumnPicker>
-    <WidgetAutocomplete
+    <AutocompleteWidget
       id="valueColumnInput"
       v-model="editedStep.value_column"
       name="Use values in..."
       :options="columnNames"
       placeholder="Select a column"
-    ></WidgetAutocomplete>
-    <WidgetAutocomplete
+    ></AutocompleteWidget>
+    <AutocompleteWidget
       id="aggregationFunctionInput"
       v-model="editedStep.agg_function"
       name="Aggregate values using..."
       :options="aggregationFunctions"
       placeholder="Aggregation function"
-    ></WidgetAutocomplete>
+    ></AutocompleteWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -35,8 +35,8 @@
 import { Prop } from 'vue-property-decorator';
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
-import WidgetMultiselect from '@/components/stepforms/WidgetMultiselect.vue';
+import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
+import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
 import { PivotStep } from '@/lib/steps';
 
@@ -45,8 +45,8 @@ import { PivotStep } from '@/lib/steps';
   name: 'pivot-step-form',
   components: {
     ColumnPicker,
-    WidgetAutocomplete,
-    WidgetMultiselect,
+    AutocompleteWidget,
+    MultiselectWidget,
   },
 })
 export default class PivotStepForm extends BaseStepForm<PivotStep> {

--- a/src/components/stepforms/RenameStepForm.vue
+++ b/src/components/stepforms/RenameStepForm.vue
@@ -7,12 +7,12 @@
       name="Old name"
       placeholder="Enter the old column name"
     ></ColumnPicker>
-    <WidgetInputText
+    <InputTextWidget
       id="newnameInput"
       v-model="editedStep.newname"
       name="By..."
       placeholder="Enter a new column name"
-    ></WidgetInputText>
+    ></InputTextWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -21,7 +21,7 @@
 import { Prop } from 'vue-property-decorator';
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import BaseStepForm from './StepForm.vue';
 import { RenameStep } from '@/lib/steps';
 
@@ -30,7 +30,7 @@ import { RenameStep } from '@/lib/steps';
   name: 'rename-step-form',
   components: {
     ColumnPicker,
-    WidgetInputText,
+    InputTextWidget,
   },
 })
 export default class RenameStepForm extends BaseStepForm<RenameStep> {

--- a/src/components/stepforms/ReplaceStepForm.vue
+++ b/src/components/stepforms/ReplaceStepForm.vue
@@ -7,21 +7,21 @@
       name="Search in column..."
       placeholder="Enter a column"
     ></ColumnPicker>
-    <WidgetInputText
+    <InputTextWidget
       id="newColumnInput"
       v-model="editedStep.new_column"
       name="(Optional) Write output in..."
       placeholder="Enter a new column name"
-    ></WidgetInputText>
-    <WidgetList
+    ></InputTextWidget>
+    <ListWidget
       addFieldName="Add a value to replace"
       id="toReplace"
       name="Values to replace:"
       v-model="toReplace"
       :defaultItem="[]"
-      :widget="widgetToReplace"
+      :widget="replaceWidget"
       :automatic-new-field="false"
-    ></WidgetList>
+    ></ListWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -31,9 +31,9 @@ import { Prop } from 'vue-property-decorator';
 import { Getter } from 'vuex-class';
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
-import WidgetList from '@/components/stepforms/WidgetList.vue';
-import WidgetToReplace from '@/components/stepforms/WidgetToReplace.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+import ListWidget from '@/components/stepforms/widgets/List.vue';
+import ReplaceWidget from '@/components/stepforms/widgets/Replace.vue';
 import BaseStepForm from './StepForm.vue';
 import { ReplaceStep } from '@/lib/steps';
 import { DataSetColumn } from '@/lib/dataset';
@@ -44,8 +44,8 @@ import { castFromString } from '@/lib/helpers';
   name: 'replace-step-form',
   components: {
     ColumnPicker,
-    WidgetInputText,
-    WidgetList,
+    InputTextWidget,
+    ListWidget,
   },
 })
 export default class ReplaceStepForm extends BaseStepForm<ReplaceStep> {
@@ -55,7 +55,7 @@ export default class ReplaceStepForm extends BaseStepForm<ReplaceStep> {
   @Getter columnHeaders!: DataSetColumn[];
 
   readonly title: string = 'Replace values';
-  widgetToReplace = WidgetToReplace;
+  replaceWidget = ReplaceWidget;
 
   get stepSelectedColumn() {
     return this.editedStep.search_column;

--- a/src/components/stepforms/SelectColumnStepForm.vue
+++ b/src/components/stepforms/SelectColumnStepForm.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
     <step-form-title :title="title"></step-form-title>
-    <WidgetMultiselect
+    <MultiselectWidget
       id="columnsInput"
       v-model="editedStep.columns"
       name="Keep columns..."
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.columns[editedStep.columns.length-1] })"
       placeholder="Add columns"
-    ></WidgetMultiselect>
+    ></MultiselectWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -16,7 +16,7 @@
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
 import { StepFormComponent } from '@/components/formlib';
-import WidgetMultiselect from '@/components/stepforms/WidgetMultiselect.vue';
+import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
 import { SelectStep } from '@/lib/steps';
 
@@ -24,7 +24,7 @@ import { SelectStep } from '@/lib/steps';
   vqbstep: 'select',
   name: 'select-step-form',
   components: {
-    WidgetMultiselect,
+    MultiselectWidget,
   },
 })
 export default class SelectStepForm extends BaseStepForm<SelectStep> {

--- a/src/components/stepforms/SortStepForm.vue
+++ b/src/components/stepforms/SortStepForm.vue
@@ -2,14 +2,14 @@
   <div>
     <step-form-title :title="title"></step-form-title>
 
-    <WidgetList
+    <ListWidget
       addFieldName="Add Column"
       id="sortColumn"
       v-model="sortColumns"
       :defaultItem="defaultSortColumn"
       :widget="widgetSortColumn"
       :automatic-new-field="false"
-    ></WidgetList>
+    ></ListWidget>
 
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
@@ -20,16 +20,16 @@ import { Prop } from 'vue-property-decorator';
 import { SortStep } from '@/lib/steps';
 import BaseStepForm from './StepForm.vue';
 import { StepFormComponent } from '@/components/formlib';
-import WidgetList from './WidgetList.vue';
+import ListWidget from './widgets/List.vue';
 import { SortColumnType } from '@/lib/steps';
-import WidgetSortColumn from './WidgetSortColumn.vue';
+import SortColumnWidget from './widgets/SortColumn.vue';
 
 @StepFormComponent({
   vqbstep: 'sort',
   name: 'sort-step-form',
   components: {
-    WidgetList,
-    WidgetSortColumn,
+    ListWidget,
+    SortColumnWidget,
   },
 })
 export default class SortStepForm extends BaseStepForm<SortStep> {
@@ -37,7 +37,7 @@ export default class SortStepForm extends BaseStepForm<SortStep> {
   initialStepValue!: SortStep;
 
   readonly title: string = 'Sort';
-  widgetSortColumn = WidgetSortColumn;
+  widgetSortColumn = SortColumnWidget;
 
   get defaultSortColumn() {
     const column = this.selectedColumns.length === 0 ? '' : this.selectedColumns[0];

--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -1,34 +1,34 @@
 <template>
   <div>
     <step-form-title :title="title"></step-form-title>
-    <WidgetInputText
+    <InputTextWidget
       id="limitInput"
       v-model.number="editedStep.limit"
       type="number"
       name="Get top..."
       placeholder="Enter a number of rows"
-    ></WidgetInputText>
+    ></InputTextWidget>
     <ColumnPicker
       id="rankOnInput"
       v-model="editedStep.rank_on"
       name="Sort column..."
       placeholder="Enter a column"
     ></ColumnPicker>
-    <WidgetAutocomplete
+    <AutocompleteWidget
       id="sortOrderInput"
       v-model="editedStep.sort"
       name="Sort order:"
       :options="['asc', 'desc']"
       placeholder="Select an order"
-    ></WidgetAutocomplete>
-    <WidgetMultiselect
+    ></AutocompleteWidget>
+    <MultiselectWidget
       id="groupbyColumnsInput"
       v-model="editedStep.groups"
       name="(Optional) Group by..."
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.groups[editedStep.groups.length-1] })"
       placeholder="Select columns"
-    ></WidgetMultiselect>
+    ></MultiselectWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -37,9 +37,9 @@
 import { Prop } from 'vue-property-decorator';
 import { TopStep } from '@/lib/steps';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
-import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
-import WidgetMultiselect from './WidgetMultiselect.vue';
+import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+import MultiselectWidget from './widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
 import { StepFormComponent } from '@/components/formlib';
 
@@ -48,9 +48,9 @@ import { StepFormComponent } from '@/components/formlib';
   name: 'top-step-form',
   components: {
     ColumnPicker,
-    WidgetAutocomplete,
-    WidgetInputText,
-    WidgetMultiselect,
+    AutocompleteWidget,
+    InputTextWidget,
+    MultiselectWidget,
   },
 })
 export default class TopStepForm extends BaseStepForm<TopStep> {

--- a/src/components/stepforms/UnpivotStepForm.vue
+++ b/src/components/stepforms/UnpivotStepForm.vue
@@ -1,35 +1,35 @@
 <template>
   <div>
     <step-form-title :title="title"></step-form-title>
-    <WidgetMultiselect
+    <MultiselectWidget
       id="keepColumnInput"
       v-model="editedStep.keep"
       name="Keep columnns..."
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.keep[0] })"
       placeholder="Add columns to keep"
-    ></WidgetMultiselect>
-    <WidgetMultiselect
+    ></MultiselectWidget>
+    <MultiselectWidget
       id="unpivotColumnInput"
       v-model="editedStep.unpivot"
       name="Unpivot columns..."
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.unpivot[0] })"
       placeholder="Add columns to unpivot"
-    ></WidgetMultiselect>
-    <WidgetInputText
+    ></MultiselectWidget>
+    <InputTextWidget
       id="unpivotColumnNameInput"
       v-model="editedStep.unpivot_column_name"
       name="Category column name"
       placeholder="Enter a column name"
-    ></WidgetInputText>
-    <WidgetInputText
+    ></InputTextWidget>
+    <InputTextWidget
       id="valueColumnNameInput"
       v-model="editedStep.value_column_name"
       name="Value column name"
       placeholder="Enter a column name"
-    ></WidgetInputText>
-    <WidgetCheckbox id="dropnaCheckbox" :label="checkboxLabel" v-model="editedStep.dropna"></WidgetCheckbox>
+    ></InputTextWidget>
+    <CheckboxWidget id="dropnaCheckbox" :label="checkboxLabel" v-model="editedStep.dropna"></CheckboxWidget>
     <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -37,9 +37,9 @@
 <script lang="ts">
 import { Prop } from 'vue-property-decorator';
 import { StepFormComponent } from '@/components/formlib';
-import WidgetCheckbox from '@/components/stepforms/WidgetCheckbox.vue';
-import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
-import WidgetMultiselect from '@/components/stepforms/WidgetMultiselect.vue';
+import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
 import { UnpivotStep } from '@/lib/steps';
 
@@ -47,9 +47,9 @@ import { UnpivotStep } from '@/lib/steps';
   vqbstep: 'unpivot',
   name: 'unpivot-step-form',
   components: {
-    WidgetCheckbox,
-    WidgetInputText,
-    WidgetMultiselect,
+    CheckboxWidget,
+    InputTextWidget,
+    MultiselectWidget,
   },
 })
 export default class UnpivotStepForm extends BaseStepForm<UnpivotStep> {

--- a/src/components/stepforms/widgets/Aggregation.vue
+++ b/src/components/stepforms/widgets/Aggregation.vue
@@ -1,19 +1,19 @@
 <template>
   <fieldset class="widget-aggregation__container">
-    <WidgetAutocomplete
+    <AutocompleteWidget
       id="columnInput"
       :options="columnNames"
       v-model="aggregation.column"
       name="Column:"
       placeholder="Enter a column"
-    ></WidgetAutocomplete>
-    <WidgetAutocomplete
+    ></AutocompleteWidget>
+    <AutocompleteWidget
       id="aggregationFunctionInput"
       v-model="aggregation.aggfunction"
       name="Function:"
       :options="aggregationFunctions"
       placeholder="Aggregation function"
-    ></WidgetAutocomplete>
+    ></AutocompleteWidget>
   </fieldset>
 </template>
 <script lang="ts">
@@ -21,15 +21,15 @@ import _ from 'lodash';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { Getter } from 'vuex-class';
 import { AggFunctionStep } from '@/lib/steps';
-import WidgetAutocomplete from './WidgetAutocomplete.vue';
+import AutocompleteWidget from './Autocomplete.vue';
 
 @Component({
-  name: 'widget-aggregation',
+  name: 'aggregation-widget',
   components: {
-    WidgetAutocomplete,
+    AutocompleteWidget,
   },
 })
-export default class WidgetAggregation extends Vue {
+export default class AggregationWidget extends Vue {
   @Prop({ type: Object, default: () => ({ column: '', aggfunction: 'sum', newcolumn: '' }) })
   value!: AggFunctionStep;
 
@@ -47,7 +47,7 @@ export default class WidgetAggregation extends Vue {
 }
 </script>
 <style lang="scss" scoped>
-@import '../../styles/_variables';
+@import '../../../styles/_variables';
 .widget-aggregation__container {
   @extend %form-widget__container;
   margin-bottom: 0;

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -17,12 +17,12 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import Multiselect from 'vue-multiselect';
 
 @Component({
-  name: 'widget-autocomplete',
+  name: 'autocomplete-widget',
   components: {
     Multiselect,
   },
 })
-export default class WidgetAutocomplete extends Vue {
+export default class AutocompleteWidget extends Vue {
   @Prop({ type: String, default: null })
   id!: string;
 
@@ -60,7 +60,7 @@ export default class WidgetAutocomplete extends Vue {
 
 <style src="vue-multiselect/dist/vue-multiselect.min.css"></style>
 <style lang="scss">
-@import '../../styles/_variables';
+@import '../../../styles/_variables';
 
 .widget-autocomplete__container {
   @extend %form-widget__container;

--- a/src/components/stepforms/widgets/Checkbox.vue
+++ b/src/components/stepforms/widgets/Checkbox.vue
@@ -8,9 +8,9 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 @Component({
-  name: 'widget-checkbox',
+  name: 'checkbox-widget',
 })
-export default class WidgetCheckobx extends Vue {
+export default class CheckboxWidget extends Vue {
   @Prop({ type: String, default: null })
   label!: string;
 
@@ -31,7 +31,7 @@ export default class WidgetCheckobx extends Vue {
 </script>
 
 <style lang="scss" scoped>
-@import '../../styles/_variables';
+@import '../../../styles/_variables';
 .widget-checkbox {
   align-items: center;
   display: flex;

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="filter-form-simple-condition__container">
     <div class="filter-form-simple-condition-column-input">
-      <WidgetAutocomplete
+      <AutocompleteWidget
         id="columnInput"
         v-model="editedValue.column"
         :options="columnNames"
         @input="setSelectedColumns({ column: editedValue.column })"
         placeholder="Column"
-      ></WidgetAutocomplete>
+      ></AutocompleteWidget>
     </div>
     <div class="filter-form-simple-condition-operator-input">
-      <WidgetAutocomplete
+      <AutocompleteWidget
         id="filterOperator"
         :value="operator"
         @input="updateStepOperator"
@@ -18,7 +18,7 @@
         placeholder="Filter operator"
         :trackBy="`operator`"
         :label="`label`"
-      ></WidgetAutocomplete>
+      ></AutocompleteWidget>
     </div>
     <component :is="inputWidget" v-model="editedValue.value" :placeholder="placeholder"></component>
   </div>
@@ -28,9 +28,9 @@
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { Getter, Mutation } from 'vuex-class';
 import { MutationCallbacks } from '@/store/mutations';
-import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
-import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
-import WidgetMultiInputText from './WidgetMultiInputText.vue';
+import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+import MultiInputTextWidget from './MultiInputText.vue';
 import { FilterSimpleCondition } from '@/lib/steps';
 import { VueConstructor } from 'vue';
 
@@ -53,13 +53,13 @@ type OperatorOption = {
 };
 
 @Component({
-  name: 'widget-filter-simple-condition',
+  name: 'filter-simple-condition-widget',
   components: {
-    WidgetAutocomplete,
-    WidgetInputText,
+    AutocompleteWidget,
+    InputTextWidget,
   },
 })
-export default class WidgetFilterSimpleCondition extends Vue {
+export default class FilterSimpleConditionWidget extends Vue {
   @Prop({
     type: Object,
     default: () => ({ column: '', value: '', operator: 'eq' }),
@@ -73,14 +73,14 @@ export default class WidgetFilterSimpleCondition extends Vue {
   editedValue: FilterSimpleCondition = { ...this.value };
 
   readonly operators: OperatorOption[] = [
-    { operator: 'eq', label: 'equal', inputWidget: WidgetInputText },
-    { operator: 'ne', label: 'not equal', inputWidget: WidgetInputText },
-    { operator: 'gt', label: 'be greater than', inputWidget: WidgetInputText },
-    { operator: 'ge', label: 'be greater than or equal to', inputWidget: WidgetInputText },
-    { operator: 'lt', label: 'be less than', inputWidget: WidgetInputText },
-    { operator: 'le', label: 'be less than or equal to', inputWidget: WidgetInputText },
-    { operator: 'in', label: 'be among', inputWidget: WidgetMultiInputText },
-    { operator: 'nin', label: 'not be among', inputWidget: WidgetMultiInputText },
+    { operator: 'eq', label: 'equal', inputWidget: InputTextWidget },
+    { operator: 'ne', label: 'not equal', inputWidget: InputTextWidget },
+    { operator: 'gt', label: 'be greater than', inputWidget: InputTextWidget },
+    { operator: 'ge', label: 'be greater than or equal to', inputWidget: InputTextWidget },
+    { operator: 'lt', label: 'be less than', inputWidget: InputTextWidget },
+    { operator: 'le', label: 'be less than or equal to', inputWidget: InputTextWidget },
+    { operator: 'in', label: 'be among', inputWidget: MultiInputTextWidget },
+    { operator: 'nin', label: 'not be among', inputWidget: MultiInputTextWidget },
   ];
 
   readonly placeholder = 'Enter a value';

--- a/src/components/stepforms/widgets/InputText.vue
+++ b/src/components/stepforms/widgets/InputText.vue
@@ -17,9 +17,9 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 @Component({
-  name: 'widget-input-text',
+  name: 'input-text-widget',
 })
-export default class WidgetInputText extends Vue {
+export default class InputTextWidget extends Vue {
   @Prop({ type: String, default: null })
   id!: string;
 
@@ -56,7 +56,7 @@ export default class WidgetInputText extends Vue {
 </script>
 
 <style lang="scss" scoped>
-@import '../../styles/_variables';
+@import '../../../styles/_variables';
 
 .widget-input-text__container {
   @extend %form-widget__container;

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -21,7 +21,7 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { VueConstructor } from 'vue';
-import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 
 type Field = {
   name: string;
@@ -32,9 +32,9 @@ type Field = {
 type RepeatableField = Field[];
 
 @Component({
-  name: 'widget-list',
+  name: 'list-widget',
 })
-export default class WidgetList extends Vue {
+export default class ListWidget extends Vue {
   @Prop({ type: String, default: '' })
   addFieldName!: string;
 
@@ -49,7 +49,7 @@ export default class WidgetList extends Vue {
 
   @Prop({
     type: Function,
-    default: WidgetInputText,
+    default: InputTextWidget,
   })
   widget!: VueConstructor<Vue>;
 
@@ -74,7 +74,7 @@ export default class WidgetList extends Vue {
     if (this.defaultItem) {
       return this.defaultItem;
     }
-    if (this.widget === WidgetInputText) {
+    if (this.widget === InputTextWidget) {
       return '';
     } else {
       return [];
@@ -107,7 +107,7 @@ export default class WidgetList extends Vue {
 }
 </script>
 <style lang="scss" scoped>
-@import '../../styles/_variables';
+@import '../../../styles/_variables';
 .fa-plus-circle {
   color: $active-color;
 }

--- a/src/components/stepforms/widgets/MultiInputText.vue
+++ b/src/components/stepforms/widgets/MultiInputText.vue
@@ -1,14 +1,18 @@
 <template>
-  <div class="widget-multiselect__container">
-    <label class="widget-multiselect__label" :for="id">{{ name }}</label>
+  <div class="widget-multiinputtext__container">
+    <label class="widget-multiinputtext__label" :for="id">{{ name }}</label>
     <multiselect
       v-model="editedValue"
       :options="options"
-      :placeholder="placeholder"
       :multiple="true"
       :taggable="true"
       :close-on-select="false"
-    ></multiselect>
+      :placeholder="placeholder"
+      @input="clearOptions"
+      @search-change="updateOptions"
+    >
+      <template slot="noOptions">{{ placeholder }}</template>
+    </multiselect>
   </div>
 </template>
 
@@ -17,12 +21,12 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import Multiselect from 'vue-multiselect';
 
 @Component({
-  name: 'widget-multiselect',
+  name: 'multi-input-text-widget',
   components: {
     Multiselect,
   },
 })
-export default class WidgetMultiselect extends Vue {
+export default class MultiInputTextWidget extends Vue {
   @Prop({ type: String, default: null })
   id!: string;
 
@@ -35,10 +39,18 @@ export default class WidgetMultiselect extends Vue {
   @Prop({ type: Array, default: () => [] })
   value!: string[];
 
-  @Prop({ type: Array, default: () => [] })
-  options!: string[];
-
   editedValue: string[] = [];
+  options: string[] = [];
+
+  clearOptions() {
+    this.options = [];
+  }
+
+  updateOptions(newVal: string) {
+    if (newVal.length > 0) {
+      this.options = [newVal];
+    }
+  }
 
   @Watch('value', { immediate: true })
   updateEditedValue(newValue: string[]) {
@@ -54,8 +66,8 @@ export default class WidgetMultiselect extends Vue {
 
 <style src="vue-multiselect/dist/vue-multiselect.min.css"></style>
 <style lang="scss">
-@import '../../styles/_variables';
-.widget-multiselect__container {
+@import '../../../styles/_variables';
+.widget-multiinputtext__container {
   @extend %form-widget__container;
   position: relative;
 }
@@ -108,7 +120,7 @@ export default class WidgetMultiselect extends Vue {
   color: $base-color-light;
 }
 
-.widget-multiselect__label {
+.widget-multiinputtext__label {
   @extend %form-widget__label;
 }
 
@@ -136,8 +148,6 @@ export default class WidgetMultiselect extends Vue {
 .multiselect__tags .multiselect__tag-icon {
   background: $active-color;
   &:after {
-    // color: #fff;
-    // color: $grey;
     color: rgba(255, 255, 255, 0.75);
   }
   &:hover {

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -1,18 +1,14 @@
 <template>
-  <div class="widget-multiinputtext__container">
-    <label class="widget-multiinputtext__label" :for="id">{{ name }}</label>
+  <div class="widget-multiselect__container">
+    <label class="widget-multiselect__label" :for="id">{{ name }}</label>
     <multiselect
       v-model="editedValue"
       :options="options"
+      :placeholder="placeholder"
       :multiple="true"
       :taggable="true"
       :close-on-select="false"
-      :placeholder="placeholder"
-      @input="clearOptions"
-      @search-change="updateOptions"
-    >
-      <template slot="noOptions">{{ placeholder }}</template>
-    </multiselect>
+    ></multiselect>
   </div>
 </template>
 
@@ -21,12 +17,12 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import Multiselect from 'vue-multiselect';
 
 @Component({
-  name: 'widget-multi-input-text',
+  name: 'multiselect-widget',
   components: {
     Multiselect,
   },
 })
-export default class WidgetMultiInputText extends Vue {
+export default class MultiselectWidget extends Vue {
   @Prop({ type: String, default: null })
   id!: string;
 
@@ -39,18 +35,10 @@ export default class WidgetMultiInputText extends Vue {
   @Prop({ type: Array, default: () => [] })
   value!: string[];
 
+  @Prop({ type: Array, default: () => [] })
+  options!: string[];
+
   editedValue: string[] = [];
-  options: string[] = [];
-
-  clearOptions() {
-    this.options = [];
-  }
-
-  updateOptions(newVal: string) {
-    if (newVal.length > 0) {
-      this.options = [newVal];
-    }
-  }
 
   @Watch('value', { immediate: true })
   updateEditedValue(newValue: string[]) {
@@ -66,8 +54,8 @@ export default class WidgetMultiInputText extends Vue {
 
 <style src="vue-multiselect/dist/vue-multiselect.min.css"></style>
 <style lang="scss">
-@import '../../styles/_variables';
-.widget-multiinputtext__container {
+@import '../../../styles/_variables';
+.widget-multiselect__container {
   @extend %form-widget__container;
   position: relative;
 }
@@ -120,7 +108,7 @@ export default class WidgetMultiInputText extends Vue {
   color: $base-color-light;
 }
 
-.widget-multiinputtext__label {
+.widget-multiselect__label {
   @extend %form-widget__label;
 }
 
@@ -148,6 +136,8 @@ export default class WidgetMultiInputText extends Vue {
 .multiselect__tags .multiselect__tag-icon {
   background: $active-color;
   &:after {
+    // color: #fff;
+    // color: $grey;
     color: rgba(255, 255, 255, 0.75);
   }
   &:hover {

--- a/src/components/stepforms/widgets/Replace.vue
+++ b/src/components/stepforms/widgets/Replace.vue
@@ -1,21 +1,21 @@
 <template>
   <div class="widget-to-replace__container">
-    <WidgetInputText id="valueToReplace" v-model="toReplace[0]" placeholder="Value to replace"></WidgetInputText>
-    <WidgetInputText id="newValue" v-model="toReplace[1]" placeholder="New value"></WidgetInputText>
+    <InputTextWidget id="valueToReplace" v-model="toReplace[0]" placeholder="Value to replace"></InputTextWidget>
+    <InputTextWidget id="newValue" v-model="toReplace[1]" placeholder="New value"></InputTextWidget>
   </div>
 </template>
 <script lang="ts">
 import _ from 'lodash';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
-import WidgetInputText from './WidgetInputText.vue';
+import InputTextWidget from './InputText.vue';
 
 @Component({
-  name: 'widget-to-replace',
+  name: 'replace-widget',
   components: {
-    WidgetInputText,
+    InputTextWidget,
   },
 })
-export default class WidgetToReplace extends Vue {
+export default class ReplaceWidget extends Vue {
   @Prop({
     type: Array,
     default: () => ['', ''],

--- a/src/components/stepforms/widgets/SortColumn.vue
+++ b/src/components/stepforms/widgets/SortColumn.vue
@@ -1,20 +1,20 @@
 <template>
   <fieldset class="widget-sort__container">
-    <WidgetAutocomplete
+    <AutocompleteWidget
       id="columnInput"
       :options="columnNames"
       v-model="sort.column"
       name="Column"
       placeholder="Enter a column"
       @input="setSelectedColumns({ column: sort.column })"
-    ></WidgetAutocomplete>
-    <WidgetAutocomplete
+    ></AutocompleteWidget>
+    <AutocompleteWidget
       id="sortOrderInput"
       v-model="sort.order"
       name="Order"
       :options="['asc', 'desc']"
       placeholder="Order by"
-    ></WidgetAutocomplete>
+    ></AutocompleteWidget>
   </fieldset>
 </template>
 <script lang="ts">
@@ -22,21 +22,16 @@ import _ from 'lodash';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { Getter, Mutation } from 'vuex-class';
 import { MutationCallbacks } from '@/store/mutations';
-import WidgetAutocomplete from './WidgetAutocomplete.vue';
+import AutocompleteWidget from './Autocomplete.vue';
 import { SortColumnType } from '@/lib/steps';
 
-const defaultValues: SortColumnType = {
-  column: '',
-  order: 'asc',
-};
-
 @Component({
-  name: 'widget-sort-column',
+  name: 'sort-column-widget',
   components: {
-    WidgetAutocomplete,
+    AutocompleteWidget,
   },
 })
-export default class WidgetSortColumn extends Vue {
+export default class SortColumnWidget extends Vue {
   @Prop({
     type: Object,
     default: () => ({

--- a/tests/unit/aggregate-step-form.spec.ts
+++ b/tests/unit/aggregate-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import AggregateStepForm from '@/components/stepforms/AggregateStepForm.vue';
-import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
-import WidgetMultiselect from '@/components/stepforms/WidgetMultiselect.vue';
+import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
+import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { Pipeline } from '@/lib/steps';
@@ -27,14 +27,14 @@ describe('Aggregate Step Form', () => {
     expect(wrapper.vm.$data.stepname).toEqual('aggregate');
   });
 
-  describe('WidgetMultiselect', () => {
-    it('should have exactly one WidgetMultiselect component', () => {
+  describe('MultiselectWidget', () => {
+    it('should have exactly one MultiselectWidget component', () => {
       const wrapper = shallowMount(AggregateStepForm, { store: emptyStore, localVue, sync: false });
-      const widgetWrappers = wrapper.findAll('widgetmultiselect-stub');
+      const widgetWrappers = wrapper.findAll('multiselectwidget-stub');
       expect(widgetWrappers.length).toEqual(1);
     });
 
-    it('should instantiate an WidgetMultiselect widget with proper options from the store', () => {
+    it('should instantiate an MultiselectWidget widget with proper options from the store', () => {
       const store = setupStore({
         dataset: {
           headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
@@ -42,34 +42,34 @@ describe('Aggregate Step Form', () => {
         },
       });
       const wrapper = shallowMount(AggregateStepForm, { store, localVue, sync: false });
-      const widgetMultiselect = wrapper.find('widgetmultiselect-stub');
+      const widgetMultiselect = wrapper.find('multiselectwidget-stub');
       expect(widgetMultiselect.attributes('options')).toEqual('columnA,columnB,columnC');
     });
 
-    it('should pass down the "on" prop to the WidgetMultiselect value prop', async () => {
+    it('should pass down the "on" prop to the MultiselectWidget value prop', async () => {
       const wrapper = shallowMount(AggregateStepForm, { store: emptyStore, localVue, sync: false });
       wrapper.setData({ editedStep: { name: 'aggregate', on: ['foo', 'bar'], aggregations: [] } });
       await wrapper.vm.$nextTick();
-      expect(wrapper.find('widgetmultiselect-stub').props().value).toEqual(['foo', 'bar']);
+      expect(wrapper.find('multiselectwidget-stub').props().value).toEqual(['foo', 'bar']);
     });
 
     it('should call the setColumnMutation on input', async () => {
       const store = emptyStore;
       const wrapper = mount(AggregateStepForm, { store, localVue, sync: false });
       wrapper.setData({ editedStep: { name: 'aggregate', on: ['foo'], aggregations: [] } });
-      await wrapper.find(WidgetMultiselect).trigger('input');
+      await wrapper.find(MultiselectWidget).trigger('input');
       expect(store.state.selectedColumns).toEqual(['foo']);
     });
   });
 
-  describe('WidgetList', () => {
-    it('should have exactly on WidgetList component', () => {
+  describe('ListWidget', () => {
+    it('should have exactly on ListWidget component', () => {
       const wrapper = shallowMount(AggregateStepForm, { store: emptyStore, localVue, sync: false });
-      const widgetWrappers = wrapper.findAll('widgetlist-stub');
+      const widgetWrappers = wrapper.findAll('listwidget-stub');
       expect(widgetWrappers.length).toEqual(1);
     });
 
-    it('should pass down the "aggregations" prop to the WidgetList value prop', async () => {
+    it('should pass down the "aggregations" prop to the ListWidget value prop', async () => {
       const wrapper = shallowMount(AggregateStepForm, { store: emptyStore, localVue, sync: false });
       wrapper.setData({
         editedStep: {
@@ -79,14 +79,14 @@ describe('Aggregate Step Form', () => {
         },
       });
       await wrapper.vm.$nextTick();
-      expect(wrapper.find('widgetlist-stub').props().value).toEqual([
+      expect(wrapper.find('listwidget-stub').props().value).toEqual([
         { column: 'foo', newcolumn: 'bar', aggfunction: 'sum' },
       ]);
     });
 
     it('should have expected default aggregation parameters', () => {
       const wrapper = mount(AggregateStepForm, { store: emptyStore, localVue, sync: false });
-      const widgetWrappers = wrapper.findAll(WidgetAutocomplete);
+      const widgetWrappers = wrapper.findAll(AutocompleteWidget);
       expect(widgetWrappers.at(0).props().value).toEqual('');
       expect(widgetWrappers.at(1).props().value).toEqual('sum');
     });
@@ -256,7 +256,7 @@ describe('Aggregate Step Form', () => {
     const store = setupStore({ selectedColumns: [] });
     const wrapper = mount(AggregateStepForm, { store, localVue, sync: false });
     wrapper.setData({ editedStep: { name: 'aggregate', on: ['foo'], aggregations: [] } });
-    wrapper.find(WidgetMultiselect).trigger('input');
+    wrapper.find(MultiselectWidget).trigger('input');
     await wrapper.vm.$nextTick();
     expect(store.state.selectedColumns).toEqual(['foo']);
   });

--- a/tests/unit/aggregation-widget.spec.ts
+++ b/tests/unit/aggregation-widget.spec.ts
@@ -1,5 +1,5 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import WidgetAggregation from '@/components/stepforms/WidgetAggregation.vue';
+import AggregationWidget from '@/components/stepforms/widgets/Aggregation.vue';
 import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { VQBState } from '@/store/state';
@@ -7,20 +7,20 @@ import { VQBState } from '@/store/state';
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
-describe('Widget WidgetAggregation', () => {
+describe('Widget AggregationWidget', () => {
   let emptyStore: Store<VQBState>;
   beforeEach(() => {
     emptyStore = setupStore({});
   });
 
   it('should instantiate', () => {
-    const wrapper = shallowMount(WidgetAggregation, { store: emptyStore, localVue });
+    const wrapper = shallowMount(AggregationWidget, { store: emptyStore, localVue });
     expect(wrapper.exists()).toBeTruthy();
   });
 
-  it('should have exactly two WidgetAutocomplete components', () => {
-    const wrapper = shallowMount(WidgetAggregation, { store: emptyStore, localVue });
-    const widgetWrappers = wrapper.findAll('widgetautocomplete-stub');
+  it('should have exactly two AutocompleteWidget components', () => {
+    const wrapper = shallowMount(AggregationWidget, { store: emptyStore, localVue });
+    const widgetWrappers = wrapper.findAll('autocompletewidget-stub');
     expect(widgetWrappers.length).toEqual(2);
   });
 
@@ -31,33 +31,33 @@ describe('Widget WidgetAggregation', () => {
         data: [],
       },
     });
-    const wrapper = shallowMount(WidgetAggregation, { store, localVue });
-    const widgetWrappers = wrapper.findAll('widgetautocomplete-stub');
+    const wrapper = shallowMount(AggregationWidget, { store, localVue });
+    const widgetWrappers = wrapper.findAll('autocompletewidget-stub');
     expect(widgetWrappers.at(0).attributes('options')).toEqual('columnA,columnB,columnC');
   });
 
-  it('should pass down the "column" prop to the first WidgetAutocomplete value prop', () => {
-    const wrapper = shallowMount(WidgetAggregation, {
+  it('should pass down the "column" prop to the first AutocompleteWidget value prop', () => {
+    const wrapper = shallowMount(AggregationWidget, {
       store: emptyStore,
       localVue,
       propsData: { value: { column: 'foo', newcolumn: '', aggfunction: 'sum' } },
     });
-    const widgetWrappers = wrapper.findAll('WidgetAutocomplete-stub');
+    const widgetWrappers = wrapper.findAll('AutocompleteWidget-stub');
     expect(widgetWrappers.at(0).props().value).toEqual('foo');
   });
 
-  it('should pass down the "aggfunction" prop to the second WidgetAutocomplete value prop', () => {
-    const wrapper = shallowMount(WidgetAggregation, {
+  it('should pass down the "aggfunction" prop to the second AutocompleteWidget value prop', () => {
+    const wrapper = shallowMount(AggregationWidget, {
       store: emptyStore,
       localVue,
       propsData: { value: { column: 'foo', newcolumn: '', aggfunction: 'avg' } },
     });
-    const widgetWrappers = wrapper.findAll('WidgetAutocomplete-stub');
+    const widgetWrappers = wrapper.findAll('AutocompleteWidget-stub');
     expect(widgetWrappers.at(1).props().value).toEqual('avg');
   });
 
   it('should emit "input" event on "aggregation" update', async () => {
-    const wrapper = shallowMount(WidgetAggregation, {
+    const wrapper = shallowMount(AggregationWidget, {
       store: emptyStore,
       localVue,
     });

--- a/tests/unit/argmax-step-form.spec.ts
+++ b/tests/unit/argmax-step-form.spec.ts
@@ -28,7 +28,7 @@ describe('Argmax Step Form', () => {
   it('should have exactly 2 input components', () => {
     const wrapper = shallowMount(ArgmaxStepForm, { store: emptyStore, localVue });
     const autocompleteWrappers = wrapper.findAll('columnpicker-stub');
-    const multiselectWrappers = wrapper.findAll('widgetmultiselect-stub');
+    const multiselectWrappers = wrapper.findAll('multiselectwidget-stub');
     expect(autocompleteWrappers.length).toEqual(1);
     expect(multiselectWrappers.length).toEqual(1);
   });
@@ -39,7 +39,7 @@ describe('Argmax Step Form', () => {
       editedStep: { name: 'argmax', column: 'foo', groups: ['bar'] },
     });
     await localVue.nextTick();
-    expect(wrapper.find('widgetmultiselect-stub').props('value')).toEqual(['bar']);
+    expect(wrapper.find('multiselectwidget-stub').props('value')).toEqual(['bar']);
   });
 
   it('should report errors if column is empty', async () => {

--- a/tests/unit/argmin-step-form.spec.ts
+++ b/tests/unit/argmin-step-form.spec.ts
@@ -28,7 +28,7 @@ describe('Argmin Step Form', () => {
   it('should have exactly 2 input components', () => {
     const wrapper = shallowMount(ArgminStepForm, { store: emptyStore, localVue });
     const autocompleteWrappers = wrapper.findAll('columnpicker-stub');
-    const multiselectWrappers = wrapper.findAll('widgetmultiselect-stub');
+    const multiselectWrappers = wrapper.findAll('multiselectwidget-stub');
     expect(autocompleteWrappers.length).toEqual(1);
     expect(multiselectWrappers.length).toEqual(1);
   });
@@ -39,7 +39,7 @@ describe('Argmin Step Form', () => {
       editedStep: { name: 'argmin', column: 'foo', groups: ['bar'] },
     });
     await localVue.nextTick();
-    expect(wrapper.find('widgetmultiselect-stub').props('value')).toEqual(['bar']);
+    expect(wrapper.find('multiselectwidget-stub').props('value')).toEqual(['bar']);
   });
 
   it('should report errors if column is empty', async () => {

--- a/tests/unit/autocomplete-widget.spec.ts
+++ b/tests/unit/autocomplete-widget.spec.ts
@@ -1,14 +1,14 @@
 import { shallowMount } from '@vue/test-utils';
-import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
+import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 
 describe('Widget Autocomplete', () => {
   it('should instantiate', () => {
-    const wrapper = shallowMount(WidgetAutocomplete);
+    const wrapper = shallowMount(AutocompleteWidget);
     expect(wrapper.exists()).toBeTruthy();
   });
 
   it('should have an instantiated Multiselect autocomplete', () => {
-    const wrapper = shallowMount(WidgetAutocomplete);
+    const wrapper = shallowMount(AutocompleteWidget);
     expect(wrapper.find('multiselect-stub').exists()).toBeTruthy();
   });
 });

--- a/tests/unit/checkbox-widget.spec.ts
+++ b/tests/unit/checkbox-widget.spec.ts
@@ -1,22 +1,22 @@
 import { mount, createLocalVue, shallowMount } from '@vue/test-utils';
-import WidgetCheckbox from '@/components/stepforms/WidgetCheckbox.vue';
+import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
 
 const localVue = createLocalVue();
 
 describe('Widget Checkbox', () => {
   it('should instantiate', () => {
-    const wrapper = shallowMount(WidgetCheckbox);
+    const wrapper = shallowMount(CheckboxWidget);
     expect(wrapper.exists()).toBeTruthy();
   });
 
   it('should have a label', () => {
-    const wrapper = shallowMount(WidgetCheckbox, { propsData: { label: 'test' } });
+    const wrapper = shallowMount(CheckboxWidget, { propsData: { label: 'test' } });
     const labelWrapper = wrapper.find('label');
     expect(labelWrapper.text()).toEqual('test');
   });
 
   it('should toggle the right class on click', async () => {
-    const wrapper = mount(WidgetCheckbox, {
+    const wrapper = mount(CheckboxWidget, {
       propsData: { value: false },
     });
     expect(wrapper.classes()).not.toContain('widget-checkbox--checked');
@@ -29,7 +29,7 @@ describe('Widget Checkbox', () => {
   });
 
   it('should emit "input" event on click', async () => {
-    const wrapper = shallowMount(WidgetCheckbox, {
+    const wrapper = shallowMount(CheckboxWidget, {
       propsData: {
         value: false,
       },

--- a/tests/unit/column-picker.spec.ts
+++ b/tests/unit/column-picker.spec.ts
@@ -20,7 +20,7 @@ describe('Column Picker', () => {
 
   it('should have a widget autocomplete', () => {
     const wrapper = shallowMount(ColumnPicker, { store: emptyStore, localVue });
-    expect(wrapper.find('widgetautocomplete-stub').exists()).toBeTruthy();
+    expect(wrapper.find('autocompletewidget-stub').exists()).toBeTruthy();
   });
 
   it('should instantiate an autocomplete widget with proper options from the store', () => {
@@ -31,7 +31,7 @@ describe('Column Picker', () => {
       },
     });
     const wrapper = shallowMount(ColumnPicker, { store, localVue });
-    const selectWrapper = wrapper.find('widgetautocomplete-stub');
+    const selectWrapper = wrapper.find('autocompletewidget-stub');
     expect(selectWrapper.attributes('options')).toEqual('columnA,columnB,columnC');
   });
 

--- a/tests/unit/delete-column-step-form.spec.ts
+++ b/tests/unit/delete-column-step-form.spec.ts
@@ -1,6 +1,6 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import DeleteColumnStepForm from '@/components/stepforms/DeleteColumnStepForm.vue';
-import WidgetMultiselect from '@/components/stepforms/WidgetMultiselect.vue';
+import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { Pipeline } from '@/lib/steps';
@@ -29,7 +29,7 @@ describe('Delete Column Step Form', () => {
   it('should have a widget multiselect', () => {
     const wrapper = shallowMount(DeleteColumnStepForm, { store: emptyStore, localVue });
 
-    expect(wrapper.find('widgetmultiselect-stub').exists()).toBeTruthy();
+    expect(wrapper.find('multiselectwidget-stub').exists()).toBeTruthy();
   });
 
   it('should instantiate a multiselect widget with proper options from the store', () => {
@@ -40,7 +40,7 @@ describe('Delete Column Step Form', () => {
       },
     });
     const wrapper = shallowMount(DeleteColumnStepForm, { store, localVue });
-    const widgetAutocomplete = wrapper.find('widgetmultiselect-stub');
+    const widgetAutocomplete = wrapper.find('multiselectwidget-stub');
 
     expect(widgetAutocomplete.attributes('options')).toEqual('columnA,columnB,columnC');
   });
@@ -108,7 +108,7 @@ describe('Delete Column Step Form', () => {
       localVue,
     });
     wrapper.setData({ editedStep: { columns: ['columnB'] } });
-    await wrapper.find(WidgetMultiselect).trigger('input');
+    await wrapper.find(MultiselectWidget).trigger('input');
     expect(store.state.selectedColumns).toEqual(['columnB']);
   });
 

--- a/tests/unit/domain-step-form.spec.ts
+++ b/tests/unit/domain-step-form.spec.ts
@@ -26,7 +26,7 @@ describe('Domain Step Form', () => {
 
   it('should have exactly one widgetautocomplete component', () => {
     const wrapper = shallowMount(DomainStepForm, { store: emptyStore, localVue });
-    const inputWrappers = wrapper.findAll('widgetautocomplete-stub');
+    const inputWrappers = wrapper.findAll('autocompletewidget-stub');
 
     expect(inputWrappers.length).toEqual(1);
   });
@@ -36,7 +36,7 @@ describe('Domain Step Form', () => {
       domains: ['foo', 'bar'],
     });
     const wrapper = shallowMount(DomainStepForm, { store, localVue });
-    const widgetAutocomplete = wrapper.find('widgetautocomplete-stub');
+    const widgetAutocomplete = wrapper.find('autocompletewidget-stub');
 
     expect(widgetAutocomplete.attributes('options')).toEqual('foo,bar');
   });

--- a/tests/unit/duplicate-column-step-form.spec.ts
+++ b/tests/unit/duplicate-column-step-form.spec.ts
@@ -29,7 +29,7 @@ describe('Duplicate Column Step Form', () => {
     const wrapper = shallowMount(DuplicateColumnStepForm, { store: emptyStore, localVue });
 
     expect(wrapper.findAll('columnpicker-stub').length).toEqual(1);
-    expect(wrapper.findAll('widgetinputtext-stub').length).toEqual(1);
+    expect(wrapper.findAll('inputtextwidget-stub').length).toEqual(1);
   });
 
   describe('Errors', () => {

--- a/tests/unit/fillna-step-form.spec.ts
+++ b/tests/unit/fillna-step-form.spec.ts
@@ -27,7 +27,7 @@ describe('Fillna Step Form', () => {
 
   it('should have exactly one widgetinputtext component', () => {
     const wrapper = shallowMount(FillnaStepForm, { store: emptyStore, localVue });
-    const inputWrappers = wrapper.findAll('widgetinputtext-stub');
+    const inputWrappers = wrapper.findAll('inputtextwidget-stub');
 
     expect(inputWrappers.length).toEqual(1);
   });
@@ -36,7 +36,7 @@ describe('Fillna Step Form', () => {
     const wrapper = shallowMount(FillnaStepForm, { store: emptyStore, localVue });
     wrapper.setData({ editedStep: { column: '', value: 'foo' } });
     await localVue.nextTick();
-    expect(wrapper.find('widgetinputtext-stub').props('value')).toEqual('foo');
+    expect(wrapper.find('inputtextwidget-stub').props('value')).toEqual('foo');
   });
 
   it('should have a columnpicker widget', () => {

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
-import WidgetFilterSimpleCondition from '@/components/stepforms/WidgetFilterSimpleCondition.vue';
-import WidgetAutocomplete from '@/components/stepforms/WidgetAutocomplete.vue';
-import WidgetMultiInputText from '@/components/stepforms/WidgetMultiInputText.vue';
+import FilterSimpleConditionWidget from '@/components/stepforms/widgets/FilterSimpleCondition.vue';
+import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
+import MultiInputTextWidget from '@/components/stepforms/widgets/MultiInputText.vue';
 import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { VQBState } from '@/store/state';
@@ -9,30 +9,30 @@ import { VQBState } from '@/store/state';
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
-describe('Widget WidgetAggregation', () => {
+describe('Widget AggregationWidget', () => {
   let emptyStore: Store<VQBState>;
   beforeEach(() => {
     emptyStore = setupStore({});
   });
 
   it('should instantiate', () => {
-    const wrapper = shallowMount(WidgetFilterSimpleCondition, { store: emptyStore, localVue });
+    const wrapper = shallowMount(FilterSimpleConditionWidget, { store: emptyStore, localVue });
     expect(wrapper.exists()).toBeTruthy();
   });
 
   it('should have exactly 3 input components', () => {
-    const wrapper = shallowMount(WidgetFilterSimpleCondition, { store: emptyStore, localVue });
-    const autocompleteWrappers = wrapper.findAll('widgetautocomplete-stub');
+    const wrapper = shallowMount(FilterSimpleConditionWidget, { store: emptyStore, localVue });
+    const autocompleteWrappers = wrapper.findAll('autocompletewidget-stub');
     expect(autocompleteWrappers.length).toEqual(2);
-    const inputtextWrappers = wrapper.findAll('widgetinputtext-stub');
+    const inputtextWrappers = wrapper.findAll('inputtextwidget-stub');
     expect(inputtextWrappers.length).toEqual(1);
   });
 
-  it('should have exactly have a WidgetMultiInputText if operator is "in" or "nin"', async () => {
-    const wrapper = shallowMount(WidgetFilterSimpleCondition, { store: emptyStore, localVue });
+  it('should have exactly have a MultiInputTextWidget if operator is "in" or "nin"', async () => {
+    const wrapper = shallowMount(FilterSimpleConditionWidget, { store: emptyStore, localVue });
     wrapper.setData({ editedValue: { column: 'foo', value: [], operator: 'in' } });
     await localVue.nextTick();
-    const autocompleteWrappers = wrapper.findAll('widgetmultiinputtext-stub');
+    const autocompleteWrappers = wrapper.findAll('multiinputtextwidget-stub');
     expect(autocompleteWrappers.length).toEqual(1);
   });
 
@@ -43,42 +43,42 @@ describe('Widget WidgetAggregation', () => {
         data: [],
       },
     });
-    const wrapper = shallowMount(WidgetFilterSimpleCondition, { store, localVue });
-    const widgetWrappers = wrapper.findAll('widgetautocomplete-stub');
+    const wrapper = shallowMount(FilterSimpleConditionWidget, { store, localVue });
+    const widgetWrappers = wrapper.findAll('autocompletewidget-stub');
     expect(widgetWrappers.at(0).attributes('options')).toEqual('columnA,columnB,columnC');
   });
 
-  it('should pass down the "column" prop to the first WidgetAutocomplete value prop', async () => {
-    const wrapper = shallowMount(WidgetFilterSimpleCondition, { store: emptyStore, localVue });
+  it('should pass down the "column" prop to the first AutocompleteWidget value prop', async () => {
+    const wrapper = shallowMount(FilterSimpleConditionWidget, { store: emptyStore, localVue });
     wrapper.setData({ editedValue: { column: 'foo', value: '', operator: 'eq' } });
     await localVue.nextTick();
-    const widgetWrappers = wrapper.findAll('widgetautocomplete-stub');
+    const widgetWrappers = wrapper.findAll('autocompletewidget-stub');
     expect(widgetWrappers.at(0).props().value).toEqual('foo');
   });
 
-  it('should pass down the "operator" prop to the second WidgetAutocomplete value prop', async () => {
-    const wrapper = shallowMount(WidgetFilterSimpleCondition, { store: emptyStore, localVue });
+  it('should pass down the "operator" prop to the second AutocompleteWidget value prop', async () => {
+    const wrapper = shallowMount(FilterSimpleConditionWidget, { store: emptyStore, localVue });
     wrapper.setData({ editedValue: { column: 'foo', value: [], operator: 'nin' } });
     await localVue.nextTick();
-    const widgetWrappers = wrapper.findAll('widgetautocomplete-stub');
+    const widgetWrappers = wrapper.findAll('autocompletewidget-stub');
     expect(widgetWrappers.at(1).props().value).toEqual({
       operator: 'nin',
       label: 'not be among',
-      inputWidget: WidgetMultiInputText,
+      inputWidget: MultiInputTextWidget,
     });
   });
 
   it('should change the type of value accordingly when switching the "operator"', async () => {
-    const wrapper = shallowMount(WidgetFilterSimpleCondition, { store: emptyStore, localVue });
+    const wrapper = shallowMount(FilterSimpleConditionWidget, { store: emptyStore, localVue });
     expect((wrapper.vm.$data.editedValue.value = ''));
     wrapper.setData({ editedValue: { column: 'foo', value: [], operator: 'in' } });
-    const operatorWrapper = wrapper.findAll('widgetautocomplete-stub').at(1);
+    const operatorWrapper = wrapper.findAll('autocompletewidget-stub').at(1);
     await operatorWrapper.trigger('input', { value: 'be among' });
     expect((wrapper.vm.$data.editedValue.value = []));
   });
 
   it('should emit "input" event on "editedValue" update', async () => {
-    const wrapper = shallowMount(WidgetFilterSimpleCondition, {
+    const wrapper = shallowMount(FilterSimpleConditionWidget, {
       store: emptyStore,
       localVue,
     });
@@ -96,7 +96,7 @@ describe('Widget WidgetAggregation', () => {
       },
       selectedColumns: ['columnA'],
     });
-    const wrapper = mount(WidgetFilterSimpleCondition, {
+    const wrapper = mount(FilterSimpleConditionWidget, {
       propsData: {
         value: { column: 'columnA', value: 'bar', operator: 'eq' },
       },
@@ -104,7 +104,7 @@ describe('Widget WidgetAggregation', () => {
       localVue,
     });
     wrapper.setData({ editedValue: { column: 'columnB', value: 'bar', operator: 'eq' } });
-    await wrapper.find(WidgetAutocomplete).trigger('input');
+    await wrapper.find(AutocompleteWidget).trigger('input');
     expect(store.state.selectedColumns).toEqual(['columnB']);
   });
 });

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -25,14 +25,14 @@ describe('Filter Step Form', () => {
     expect(wrapper.vm.$data.stepname).toEqual('filter');
   });
 
-  describe('WidgetList', () => {
-    it('should have exactly on WidgetList component', () => {
+  describe('ListWidget', () => {
+    it('should have exactly on ListWidget component', () => {
       const wrapper = shallowMount(FilterStepForm, { store: emptyStore, localVue });
-      const widgetWrappers = wrapper.findAll('widgetlist-stub');
+      const widgetWrappers = wrapper.findAll('listwidget-stub');
       expect(widgetWrappers.length).toEqual(1);
     });
 
-    it('should pass down the "condition" prop to the WidgetList value prop', async () => {
+    it('should pass down the "condition" prop to the ListWidget value prop', async () => {
       const wrapper = shallowMount(FilterStepForm, { store: emptyStore, localVue });
       wrapper.setData({
         editedStep: {
@@ -41,7 +41,7 @@ describe('Filter Step Form', () => {
         },
       });
       await localVue.nextTick();
-      expect(wrapper.find('widgetlist-stub').props().value).toEqual([
+      expect(wrapper.find('listwidget-stub').props().value).toEqual([
         { column: 'foo', value: 'bar', operator: 'gt' },
       ]);
     });

--- a/tests/unit/formula-step-form.spec.ts
+++ b/tests/unit/formula-step-form.spec.ts
@@ -27,7 +27,7 @@ describe('Rename Step Form', () => {
 
   it('should have exactly 2 widgetinputtext component', () => {
     const wrapper = shallowMount(FormulaStepForm, { store: emptyStore, localVue });
-    const inputWrappers = wrapper.findAll('widgetinputtext-stub');
+    const inputWrappers = wrapper.findAll('inputtextwidget-stub');
     expect(inputWrappers.length).toEqual(2);
   });
 
@@ -37,13 +37,13 @@ describe('Rename Step Form', () => {
     await localVue.nextTick();
     expect(
       wrapper
-        .findAll('widgetinputtext-stub')
+        .findAll('inputtextwidget-stub')
         .at(0)
         .props('value'),
     ).toEqual('ColumnA * 2');
     expect(
       wrapper
-        .findAll('widgetinputtext-stub')
+        .findAll('inputtextwidget-stub')
         .at(1)
         .props('value'),
     ).toEqual('foo');

--- a/tests/unit/input-text-widget.spec.ts
+++ b/tests/unit/input-text-widget.spec.ts
@@ -1,29 +1,29 @@
 import { shallowMount } from '@vue/test-utils';
 import Vue from 'vue';
-import WidgetInputText from '@/components/stepforms/WidgetInputText.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 
 describe('Widget Input Text', () => {
   it('should instantiate', () => {
-    const wrapper = shallowMount(WidgetInputText);
+    const wrapper = shallowMount(InputTextWidget);
 
     expect(wrapper.exists()).toBeTruthy();
   });
 
   it('should have a text input', () => {
-    const wrapper = shallowMount(WidgetInputText);
+    const wrapper = shallowMount(InputTextWidget);
 
     expect(wrapper.find("input[type='text']").exists()).toBeTruthy();
   });
 
   it('should have an empty label', () => {
-    const wrapper = shallowMount(WidgetInputText);
+    const wrapper = shallowMount(InputTextWidget);
     const labelWrapper = wrapper.find('label');
 
     expect(labelWrapper.text()).toEqual('');
   });
 
   it('should have a label', () => {
-    const wrapper = shallowMount(WidgetInputText, {
+    const wrapper = shallowMount(InputTextWidget, {
       propsData: {
         name: 'Stark',
       },
@@ -34,7 +34,7 @@ describe('Widget Input Text', () => {
   });
 
   it('should have an empty placeholder', () => {
-    const wrapper = shallowMount(WidgetInputText, {
+    const wrapper = shallowMount(InputTextWidget, {
       propsData: {
         value: 'foo',
       },
@@ -45,7 +45,7 @@ describe('Widget Input Text', () => {
   });
 
   it('should have a placeholder', () => {
-    const wrapper = shallowMount(WidgetInputText, {
+    const wrapper = shallowMount(InputTextWidget, {
       propsData: {
         placeholder: 'I m a placeholder',
         value: 'foo',
@@ -57,14 +57,14 @@ describe('Widget Input Text', () => {
   });
 
   it('should have an empty input', () => {
-    const wrapper = shallowMount(WidgetInputText);
+    const wrapper = shallowMount(InputTextWidget);
     const el = wrapper.find("input[type='text']").element as HTMLInputElement;
 
     expect(el.value).toEqual('');
   });
 
   it('should have a non empty input', () => {
-    const wrapper = shallowMount(WidgetInputText, {
+    const wrapper = shallowMount(InputTextWidget, {
       propsData: { value: 'foo' },
     });
     const el = wrapper.find("input[type='text']").element as HTMLInputElement;
@@ -73,7 +73,7 @@ describe('Widget Input Text', () => {
   });
 
   it('should add the right class on focus', async () => {
-    const wrapper = shallowMount(WidgetInputText, {
+    const wrapper = shallowMount(InputTextWidget, {
       propsData: { value: 'foo' },
     });
     const inputWrapper = wrapper.find("input[type='text']");
@@ -84,7 +84,7 @@ describe('Widget Input Text', () => {
   });
 
   it('should emit "input" event on update', () => {
-    const wrapper = shallowMount(WidgetInputText, {
+    const wrapper = shallowMount(InputTextWidget, {
       propsData: {
         value: 'Star',
       },
@@ -96,7 +96,7 @@ describe('Widget Input Text', () => {
   });
 
   it('should set / unset "isFocused" on focus / blur events', () => {
-    const wrapper = shallowMount(WidgetInputText);
+    const wrapper = shallowMount(InputTextWidget);
     const inputWrapper = wrapper.find('input[type="text"]');
     inputWrapper.trigger('focus');
     expect(wrapper.vm.$data.isFocused).toBeTruthy();

--- a/tests/unit/list-widget.spec.ts
+++ b/tests/unit/list-widget.spec.ts
@@ -1,17 +1,17 @@
 import { shallowMount } from '@vue/test-utils';
-import WidgetList from '@/components/stepforms/WidgetList.vue';
-import WidgetAggregation from '@/components/stepforms/WidgetAggregation.vue';
+import ListWidget from '@/components/stepforms/widgets/List.vue';
+import AggregationWidget from '@/components/stepforms/widgets/Aggregation.vue';
 
 describe('Widget List', () => {
   describe('automatic new field', () => {
     it('it should instantiate', () => {
-      const wrapper = shallowMount(WidgetList);
+      const wrapper = shallowMount(ListWidget);
 
       expect(wrapper.exists()).toBeTruthy();
     });
 
     it('should have a label', () => {
-      const wrapper = shallowMount(WidgetList, {
+      const wrapper = shallowMount(ListWidget, {
         propsData: {
           name: 'Label',
         },
@@ -21,34 +21,33 @@ describe('Widget List', () => {
     });
 
     it('should instantiate a widget-input text', () => {
-      const wrapper = shallowMount(WidgetList);
-      const widgetInputWrapper = wrapper.find('widgetinputtext-stub');
-
+      const wrapper = shallowMount(ListWidget);
+      const widgetInputWrapper = wrapper.find('inputtextwidget-stub');
       expect(widgetInputWrapper.exists()).toBeTruthy();
     });
 
     it('should instantiate a widget aggregation', () => {
-      const wrapper = shallowMount(WidgetList, {
+      const wrapper = shallowMount(ListWidget, {
         propsData: {
-          widget: WidgetAggregation,
+          widget: AggregationWidget,
           defaultItem: { name: 'foo', value: 'bar' },
         },
       });
 
-      const widgetAggregationtWrapper = wrapper.find('widgetaggregation-stub');
+      const widgetAggregationtWrapper = wrapper.find('aggregationwidget-stub');
       expect(widgetAggregationtWrapper.exists()).toBeTruthy();
     });
 
     it('should automatically add an input when filling the first one', async () => {
-      const wrapper = shallowMount(WidgetList);
+      const wrapper = shallowMount(ListWidget);
       wrapper.setProps({ value: [{ column: 'foo', aggfunction: 'sum', newcolumn: 'bar' }] });
 
       await wrapper.vm.$nextTick();
-      expect(wrapper.findAll('widgetinputtext-stub').length).toEqual(2);
+      expect(wrapper.findAll('inputtextwidget-stub').length).toEqual(2);
     });
 
     it('should add trash icons after first input', async () => {
-      const wrapper = shallowMount(WidgetList);
+      const wrapper = shallowMount(ListWidget);
       expect(wrapper.findAll('.widget-list__icon').length).toEqual(0);
       wrapper.setProps({ value: [{ column: 'foo', aggfunction: 'sum', newcolumn: 'bar' }] });
       await wrapper.vm.$nextTick();
@@ -56,7 +55,7 @@ describe('Widget List', () => {
     });
 
     it('should remove first input when clickng on trash', async () => {
-      const wrapper = shallowMount(WidgetList, {
+      const wrapper = shallowMount(ListWidget, {
         propsData: {
           value: [{ column: 'foo', aggfunction: 'sum', newcolumn: 'bar' }],
         },
@@ -69,7 +68,7 @@ describe('Widget List', () => {
 
   describe('not automatic new field', () => {
     it('should have a button to add a new field', () => {
-      const wrapper = shallowMount(WidgetList, {
+      const wrapper = shallowMount(ListWidget, {
         propsData: {
           automaticNewField: false,
           name: 'Aggregation',
@@ -83,7 +82,7 @@ describe('Widget List', () => {
     });
 
     it('should add a new field when clicking on the button "Add Aggregation"', () => {
-      const wrapper = shallowMount(WidgetList, {
+      const wrapper = shallowMount(ListWidget, {
         propsData: {
           automaticNewField: false,
           name: 'Aggregation',

--- a/tests/unit/multi-input-text-widget.spec.ts
+++ b/tests/unit/multi-input-text-widget.spec.ts
@@ -1,5 +1,5 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import WidgetMultiInputText from '@/components/stepforms/WidgetMultiInputText.vue';
+import MultiInputTextWidget from '@/components/stepforms/widgets/MultiInputText.vue';
 import Vuex from 'vuex';
 
 const localVue = createLocalVue();
@@ -7,12 +7,12 @@ localVue.use(Vuex);
 
 describe('Widget MultisInputText', () => {
   it('should instantiate', () => {
-    const wrapper = shallowMount(WidgetMultiInputText);
+    const wrapper = shallowMount(MultiInputTextWidget);
     expect(wrapper.exists()).toBeTruthy();
   });
 
   it('should have a label', () => {
-    const wrapper = shallowMount(WidgetMultiInputText, {
+    const wrapper = shallowMount(MultiInputTextWidget, {
       propsData: {
         name: 'Stark',
       },
@@ -22,7 +22,7 @@ describe('Widget MultisInputText', () => {
   });
 
   it('should have an empty placeholder', () => {
-    const wrapper = shallowMount(WidgetMultiInputText, {
+    const wrapper = shallowMount(MultiInputTextWidget, {
       propsData: {
         value: ['foo'],
       },
@@ -32,7 +32,7 @@ describe('Widget MultisInputText', () => {
   });
 
   it('should have a placeholder', () => {
-    const wrapper = shallowMount(WidgetMultiInputText, {
+    const wrapper = shallowMount(MultiInputTextWidget, {
       propsData: {
         placeholder: 'I m a placeholder',
         value: ['foo'],
@@ -43,13 +43,13 @@ describe('Widget MultisInputText', () => {
   });
 
   it('should have an empty input', () => {
-    const wrapper = shallowMount(WidgetMultiInputText);
+    const wrapper = shallowMount(MultiInputTextWidget);
     const multiselect = wrapper.find('multiselect-stub');
     expect(multiselect.attributes().value).toEqual('');
   });
 
   it('should have a non empty input', () => {
-    const wrapper = shallowMount(WidgetMultiInputText, {
+    const wrapper = shallowMount(MultiInputTextWidget, {
       propsData: { value: ['foo'] },
     });
     const multiselect = wrapper.find('multiselect-stub');
@@ -57,20 +57,20 @@ describe('Widget MultisInputText', () => {
   });
 
   it('should update "options" on search-change event', () => {
-    const wrapper = shallowMount(WidgetMultiInputText);
+    const wrapper = shallowMount(MultiInputTextWidget);
     const multiselect = wrapper.find('multiselect-stub');
     multiselect.vm.$emit('search-change', 'Foo');
     expect(wrapper.vm.$data.options).toEqual(['Foo']);
   });
 
   it('should emit "input" event on editedValue update', async () => {
-    const wrapper = shallowMount(WidgetMultiInputText);
+    const wrapper = shallowMount(MultiInputTextWidget);
     await wrapper.setData({ editedValue: ['Foo'] });
     expect(wrapper.emitted()).toEqual({ input: [[['Foo']]] });
   });
 
   it('should clear "options" on input', () => {
-    const wrapper = shallowMount(WidgetMultiInputText);
+    const wrapper = shallowMount(MultiInputTextWidget);
     wrapper.setData({ options: ['Foo'] });
     expect(wrapper.vm.$data.options).toEqual(['Foo']);
     wrapper.find('multiselect-stub').vm.$emit('input');
@@ -78,7 +78,7 @@ describe('Widget MultisInputText', () => {
   });
 
   it('should set "editedValue" initially"', async () => {
-    const wrapper = shallowMount(WidgetMultiInputText, { propsData: { value: ['Foo'] } });
+    const wrapper = shallowMount(MultiInputTextWidget, { propsData: { value: ['Foo'] } });
     expect(wrapper.vm.$data.editedValue).toEqual(['Foo']);
   });
 });

--- a/tests/unit/multiselect-widget.spec.ts
+++ b/tests/unit/multiselect-widget.spec.ts
@@ -1,15 +1,15 @@
 import { shallowMount } from '@vue/test-utils';
-import WidgetMultiSelect from '@/components/stepforms/WidgetInputText.vue';
+import MultiSelectWidget from '@/components/stepforms/widgets/InputText.vue';
 
 describe('Widget Multiselect', () => {
   it('should instantiate', () => {
-    const wrapper = shallowMount(WidgetMultiSelect);
+    const wrapper = shallowMount(MultiSelectWidget);
 
     expect(wrapper.exists()).toBeTruthy();
   });
 
   it('should have a label', () => {
-    const wrapper = shallowMount(WidgetMultiSelect, {
+    const wrapper = shallowMount(MultiSelectWidget, {
       propsData: {
         name: 'Stark',
       },
@@ -19,7 +19,7 @@ describe('Widget Multiselect', () => {
   });
 
   it('should have an empty placeholder', () => {
-    const wrapper = shallowMount(WidgetMultiSelect, {
+    const wrapper = shallowMount(MultiSelectWidget, {
       propsData: {
         value: 'foo',
       },
@@ -29,7 +29,7 @@ describe('Widget Multiselect', () => {
   });
 
   it('should have a placeholder', () => {
-    const wrapper = shallowMount(WidgetMultiSelect, {
+    const wrapper = shallowMount(MultiSelectWidget, {
       propsData: {
         placeholder: 'I m a placeholder',
         value: 'foo',
@@ -40,13 +40,13 @@ describe('Widget Multiselect', () => {
   });
 
   it('should have an empty input', () => {
-    const wrapper = shallowMount(WidgetMultiSelect);
+    const wrapper = shallowMount(MultiSelectWidget);
     const el = wrapper.find("input[type='text']").element as HTMLInputElement;
     expect(el.value).toEqual('');
   });
 
   it('should have a non empty input', () => {
-    const wrapper = shallowMount(WidgetMultiSelect, {
+    const wrapper = shallowMount(MultiSelectWidget, {
       propsData: { value: 'foo' },
     });
     const el = wrapper.find("input[type='text']").element as HTMLInputElement;
@@ -54,7 +54,7 @@ describe('Widget Multiselect', () => {
   });
 
   it('should emit "input" event on update', () => {
-    const wrapper = shallowMount(WidgetMultiSelect, {
+    const wrapper = shallowMount(MultiSelectWidget, {
       propsData: {
         value: ['Foo'],
       },

--- a/tests/unit/percentage-step-form.spec.ts
+++ b/tests/unit/percentage-step-form.spec.ts
@@ -28,8 +28,8 @@ describe('Percentage Step Form', () => {
   it('should have exactly 3 input components', () => {
     const wrapper = shallowMount(PercentageStepForm, { store: emptyStore, localVue });
     const autocompleteWrappers = wrapper.findAll('columnpicker-stub');
-    const multiselectWrappers = wrapper.findAll('widgetmultiselect-stub');
-    const textInputWrappers = wrapper.findAll('widgetinputtext-stub');
+    const multiselectWrappers = wrapper.findAll('multiselectwidget-stub');
+    const textInputWrappers = wrapper.findAll('inputtextwidget-stub');
     expect(autocompleteWrappers.length).toEqual(1);
     expect(multiselectWrappers.length).toEqual(1);
     expect(textInputWrappers.length).toEqual(1);
@@ -41,8 +41,8 @@ describe('Percentage Step Form', () => {
       editedStep: { name: 'percentage', column: 'foo', group: ['test'], new_column: 'bar' },
     });
     await localVue.nextTick();
-    expect(wrapper.find('widgetmultiselect-stub').props('value')).toEqual(['test']);
-    expect(wrapper.find('widgetinputtext-stub').props('value')).toEqual('bar');
+    expect(wrapper.find('multiselectwidget-stub').props('value')).toEqual(['test']);
+    expect(wrapper.find('inputtextwidget-stub').props('value')).toEqual('bar');
   });
 
   describe('Errors', () => {

--- a/tests/unit/pivot-step-form.spec.ts
+++ b/tests/unit/pivot-step-form.spec.ts
@@ -26,9 +26,9 @@ describe('Pivot Step Form', () => {
 
   it('should have 4 input components', () => {
     const wrapper = shallowMount(PivotStepForm, { store: emptyStore, localVue });
-    const multiselectWrappers = wrapper.findAll('widgetmultiselect-stub');
+    const multiselectWrappers = wrapper.findAll('multiselectwidget-stub');
     const columnpickerWrappers = wrapper.findAll('columnpicker-stub');
-    const autocompleteWrappers = wrapper.findAll('widgetautocomplete-stub');
+    const autocompleteWrappers = wrapper.findAll('autocompletewidget-stub');
     expect(multiselectWrappers.length).toEqual(1);
     expect(columnpickerWrappers.length).toEqual(1);
     expect(autocompleteWrappers.length).toEqual(2);

--- a/tests/unit/rename-step-form.spec.ts
+++ b/tests/unit/rename-step-form.spec.ts
@@ -28,7 +28,7 @@ describe('Rename Step Form', () => {
 
   it('should have exactly one widgetinputtext component', () => {
     const wrapper = shallowMount(RenameStepForm, { store: emptyStore, localVue });
-    const inputWrappers = wrapper.findAll('widgetinputtext-stub');
+    const inputWrappers = wrapper.findAll('inputtextwidget-stub');
 
     expect(inputWrappers.length).toEqual(1);
   });
@@ -37,7 +37,7 @@ describe('Rename Step Form', () => {
     const wrapper = shallowMount(RenameStepForm, { store: emptyStore, localVue });
     wrapper.setData({ editedStep: { name: 'rename', oldname: '', newname: 'foo' } });
     await localVue.nextTick();
-    expect(wrapper.find('widgetinputtext-stub').props('value')).toEqual('foo');
+    expect(wrapper.find('inputtextwidget-stub').props('value')).toEqual('foo');
   });
 
   it('should have a columnpicker widget', () => {

--- a/tests/unit/replace-step-form.spec.ts
+++ b/tests/unit/replace-step-form.spec.ts
@@ -28,8 +28,8 @@ describe('Replace Step Form', () => {
   it('should have exactly 3 input components', () => {
     const wrapper = shallowMount(ReplaceStepForm, { store: emptyStore, localVue, sync: false });
     const columnPickerWrappers = wrapper.findAll('columnpicker-stub');
-    const inputTextWrappers = wrapper.findAll('widgetinputtext-stub');
-    const widgetListWrappers = wrapper.findAll('widgetlist-stub');
+    const inputTextWrappers = wrapper.findAll('inputtextwidget-stub');
+    const widgetListWrappers = wrapper.findAll('listwidget-stub');
     expect(columnPickerWrappers.length).toEqual(1);
     expect(inputTextWrappers.length).toEqual(1);
     expect(widgetListWrappers.length).toEqual(1);
@@ -53,7 +53,7 @@ describe('Replace Step Form', () => {
     expect(wrapper.find('columnpicker-stub').attributes().value).toEqual('test');
   });
 
-  it('should pass down "new_column" to WidgetInputText', () => {
+  it('should pass down "new_column" to InputTextWidget', () => {
     const wrapper = shallowMount(ReplaceStepForm, {
       store: emptyStore,
       localVue,
@@ -69,10 +69,10 @@ describe('Replace Step Form', () => {
         };
       },
     });
-    expect(wrapper.find('widgetinputtext-stub').props().value).toEqual('newTest');
+    expect(wrapper.find('inputtextwidget-stub').props().value).toEqual('newTest');
   });
 
-  it('should pass down "to_replace" to WidgetList', () => {
+  it('should pass down "to_replace" to ListWidget', () => {
     const wrapper = shallowMount(ReplaceStepForm, {
       store: emptyStore,
       localVue,
@@ -88,10 +88,10 @@ describe('Replace Step Form', () => {
         };
       },
     });
-    expect(wrapper.find('widgetlist-stub').props().value).toEqual([['foo', 'bar']]);
+    expect(wrapper.find('listwidget-stub').props().value).toEqual([['foo', 'bar']]);
   });
 
-  it('should pass down the default "to_replace" to WidgetList', () => {
+  it('should pass down the default "to_replace" to ListWidget', () => {
     const wrapper = shallowMount(ReplaceStepForm, {
       store: emptyStore,
       localVue,
@@ -107,7 +107,7 @@ describe('Replace Step Form', () => {
         };
       },
     });
-    expect(wrapper.find('widgetlist-stub').props().value).toEqual([[]]);
+    expect(wrapper.find('listwidget-stub').props().value).toEqual([[]]);
   });
 
   it('should report errors when the data is not valid', async () => {

--- a/tests/unit/replace-widget.spec.ts
+++ b/tests/unit/replace-widget.spec.ts
@@ -1,5 +1,5 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import WidgetToReplace from '@/components/stepforms/WidgetToReplace.vue';
+import ReplaceWidget from '@/components/stepforms/widgets/Replace.vue';
 import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { VQBState } from '@/store/state';
@@ -7,25 +7,25 @@ import { VQBState } from '@/store/state';
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
-describe('Widget WidgetToReplace', () => {
+describe('Widget ReplaceWidget', () => {
   let emptyStore: Store<VQBState>;
   beforeEach(() => {
     emptyStore = setupStore({});
   });
 
   it('should instantiate', () => {
-    const wrapper = shallowMount(WidgetToReplace, { store: emptyStore, localVue, sync: false });
+    const wrapper = shallowMount(ReplaceWidget, { store: emptyStore, localVue, sync: false });
     expect(wrapper.exists()).toBeTruthy();
   });
 
-  it('should have exactly two WidgetInputText components', () => {
-    const wrapper = shallowMount(WidgetToReplace, { store: emptyStore, localVue, sync: false });
-    const widgetWrappers = wrapper.findAll('widgetinputtext-stub');
+  it('should have exactly two InputTextWidget components', () => {
+    const wrapper = shallowMount(ReplaceWidget, { store: emptyStore, localVue, sync: false });
+    const widgetWrappers = wrapper.findAll('inputtextwidget-stub');
     expect(widgetWrappers.length).toEqual(2);
   });
 
   it('should pass down the properties to the input components', () => {
-    const wrapper = shallowMount(WidgetToReplace, {
+    const wrapper = shallowMount(ReplaceWidget, {
       store: emptyStore,
       localVue,
       sync: false,
@@ -33,13 +33,13 @@ describe('Widget WidgetToReplace', () => {
         return { toReplace: ['foo', 'bar'] };
       },
     });
-    const widgetWrappers = wrapper.findAll('widgetinputtext-stub');
+    const widgetWrappers = wrapper.findAll('inputtextwidget-stub');
     expect(widgetWrappers.at(0).props().value).toEqual('foo');
     expect(widgetWrappers.at(1).props().value).toEqual('bar');
   });
 
   it('should emit "input" event on "toReplace" update', async () => {
-    const wrapper = shallowMount(WidgetToReplace, {
+    const wrapper = shallowMount(ReplaceWidget, {
       store: emptyStore,
       localVue,
       sync: false,

--- a/tests/unit/select-column-step-form.spec.ts
+++ b/tests/unit/select-column-step-form.spec.ts
@@ -1,6 +1,6 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import SelectColumnStepForm from '@/components/stepforms/SelectColumnStepForm.vue';
-import WidgetMultiselect from '@/components/stepforms/WidgetMultiselect.vue';
+import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { Pipeline } from '@/lib/steps';
@@ -29,7 +29,7 @@ describe('Select Column Step Form', () => {
   it('should have a widget multiselect', () => {
     const wrapper = shallowMount(SelectColumnStepForm, { store: emptyStore, localVue });
 
-    expect(wrapper.find('widgetmultiselect-stub').exists()).toBeTruthy();
+    expect(wrapper.find('multiselectwidget-stub').exists()).toBeTruthy();
   });
 
   it('should instantiate a multiselect widget with proper options from the store', () => {
@@ -40,7 +40,7 @@ describe('Select Column Step Form', () => {
       },
     });
     const wrapper = shallowMount(SelectColumnStepForm, { store, localVue });
-    const widgetAutocomplete = wrapper.find('widgetmultiselect-stub');
+    const widgetAutocomplete = wrapper.find('multiselectwidget-stub');
 
     expect(widgetAutocomplete.attributes('options')).toEqual('columnA,columnB,columnC');
   });
@@ -108,7 +108,7 @@ describe('Select Column Step Form', () => {
       localVue,
     });
     wrapper.setData({ editedStep: { columns: ['columnB'] } });
-    await wrapper.find(WidgetMultiselect).trigger('input');
+    await wrapper.find(MultiselectWidget).trigger('input');
     expect(store.state.selectedColumns).toEqual(['columnB']);
   });
 

--- a/tests/unit/sort-column-widget.spec.ts
+++ b/tests/unit/sort-column-widget.spec.ts
@@ -1,5 +1,5 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import WidgetSortColumn from '@/components/stepforms/WidgetSortColumn.vue';
+import SortColumnWidget from '@/components/stepforms/widgets/SortColumn.vue';
 import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { VQBState } from '@/store/state';
@@ -14,13 +14,13 @@ describe('Widget sort column', () => {
   });
 
   it('should instantiate', () => {
-    const wrapper = shallowMount(WidgetSortColumn, { store: emptyStore, localVue });
+    const wrapper = shallowMount(SortColumnWidget, { store: emptyStore, localVue });
     expect(wrapper.exists()).toBeTruthy();
   });
 
-  it('should have exactly two WidgetAutocomplete components', () => {
-    const wrapper = shallowMount(WidgetSortColumn, { store: emptyStore, localVue });
-    const widgetWrappers = wrapper.findAll('widgetautocomplete-stub');
+  it('should have exactly two AutocompleteWidget components', () => {
+    const wrapper = shallowMount(SortColumnWidget, { store: emptyStore, localVue });
+    const widgetWrappers = wrapper.findAll('autocompletewidget-stub');
     expect(widgetWrappers.length).toEqual(2);
   });
 
@@ -31,29 +31,29 @@ describe('Widget sort column', () => {
         data: [],
       },
     });
-    const wrapper = shallowMount(WidgetSortColumn, { store, localVue });
-    const widgetWrappers = wrapper.findAll('widgetautocomplete-stub');
+    const wrapper = shallowMount(SortColumnWidget, { store, localVue });
+    const widgetWrappers = wrapper.findAll('autocompletewidget-stub');
     expect(widgetWrappers.at(0).attributes('options')).toEqual('columnA,columnB,columnC');
   });
 
-  it('should pass down the "column" prop to the first WidgetAutocomplete value prop', async () => {
-    const wrapper = shallowMount(WidgetSortColumn, { store: emptyStore, localVue });
+  it('should pass down the "column" prop to the first AutocompleteWidget value prop', async () => {
+    const wrapper = shallowMount(SortColumnWidget, { store: emptyStore, localVue });
     wrapper.setProps({ value: { column: 'foo', order: 'asc' } });
     await localVue.nextTick();
-    const widgetWrappers = wrapper.findAll('WidgetAutocomplete-stub');
+    const widgetWrappers = wrapper.findAll('AutocompleteWidget-stub');
     expect(widgetWrappers.at(0).props().value).toEqual('foo');
   });
 
-  it('should pass down the "order" prop to the second WidgetAutocomplete value prop', async () => {
-    const wrapper = shallowMount(WidgetSortColumn, { store: emptyStore, localVue });
+  it('should pass down the "order" prop to the second AutocompleteWidget value prop', async () => {
+    const wrapper = shallowMount(SortColumnWidget, { store: emptyStore, localVue });
     wrapper.setProps({ value: { column: 'foo', order: 'desc' } });
     await localVue.nextTick();
-    const widgetWrappers = wrapper.findAll('WidgetAutocomplete-stub');
+    const widgetWrappers = wrapper.findAll('AutocompleteWidget-stub');
     expect(widgetWrappers.at(1).props().value).toEqual('desc');
   });
 
   it('should emit "input" event on "value" update', async () => {
-    const wrapper = shallowMount(WidgetSortColumn, {
+    const wrapper = shallowMount(SortColumnWidget, {
       store: emptyStore,
       localVue,
     });

--- a/tests/unit/sort-step-form.spec.ts
+++ b/tests/unit/sort-step-form.spec.ts
@@ -24,17 +24,17 @@ describe('Sort Step Form', () => {
     expect(wrapper.exists()).toBeTruthy();
   });
 
-  describe('WidgetList', () => {
+  describe('ListWidget', () => {
     it('should have one widgetList component', () => {
       const wrapper = shallowMount(SortStepForm, { store: emptyStore, localVue, sync: false });
-      const widgetListWrapper = wrapper.findAll('widgetlist-stub');
+      const widgetListWrapper = wrapper.findAll('listwidget-stub');
       expect(widgetListWrapper.length).toEqual(1);
     });
 
     it('should pass the defaultSortColumn props to widgetList', async () => {
       const wrapper = shallowMount(SortStepForm, { store: emptyStore, localVue, sync: false });
       await localVue.nextTick();
-      expect(wrapper.find('widgetlist-stub').props().value).toEqual([{ column: '', order: 'asc' }]);
+      expect(wrapper.find('listwidget-stub').props().value).toEqual([{ column: '', order: 'asc' }]);
     });
 
     it('should pass right sort props to widgetList sort column', async () => {
@@ -46,7 +46,7 @@ describe('Sort Step Form', () => {
         },
       });
       await localVue.nextTick();
-      expect(wrapper.find('widgetlist-stub').props().value).toEqual([
+      expect(wrapper.find('listwidget-stub').props().value).toEqual([
         { column: 'amazing', order: 'desc' },
       ]);
     });

--- a/tests/unit/unpivot-step-form.spec.ts
+++ b/tests/unit/unpivot-step-form.spec.ts
@@ -4,7 +4,7 @@ import Vuex, { Store } from 'vuex';
 import { setupStore } from '@/store';
 import { Pipeline } from '@/lib/steps';
 import { VQBState } from '@/store/state';
-import WidgetCheckbox from '@/components/stepforms/WidgetCheckbox.vue';
+import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -28,11 +28,11 @@ describe('Unpivot Step Form', () => {
 
   it('should have 5 input components', () => {
     const wrapper = shallowMount(UnpivotStepForm, { store: emptyStore, localVue });
-    const autocompleteWrappers = wrapper.findAll('widgetmultiselect-stub');
+    const autocompleteWrappers = wrapper.findAll('multiselectwidget-stub');
     expect(autocompleteWrappers.length).toEqual(2);
-    const inputWrappers = wrapper.findAll('widgetinputtext-stub');
+    const inputWrappers = wrapper.findAll('inputtextwidget-stub');
     expect(inputWrappers.length).toEqual(2);
-    const checkboxWrappers = wrapper.findAll('widgetcheckbox-stub');
+    const checkboxWrappers = wrapper.findAll('checkboxwidget-stub');
     expect(checkboxWrappers.length).toEqual(1);
   });
 
@@ -57,7 +57,7 @@ describe('Unpivot Step Form', () => {
     expect(wrapper.find('#unpivotColumnInput').props('value')).toEqual(['baz']);
     expect(wrapper.find('#unpivotColumnNameInput').props('value')).toEqual('spam');
     expect(wrapper.find('#valueColumnNameInput').props('value')).toEqual('eggs');
-    const widgetCheckbox = wrapper.find(WidgetCheckbox);
+    const widgetCheckbox = wrapper.find(CheckboxWidget);
     expect(widgetCheckbox.classes()).not.toContain('widget-checkbox--checked');
   });
 


### PR DESCRIPTION
put all widget modules in `@/components/stepforms/widgets` and stop naming
widget with `WidgetXXX` names, use `XXXWidget` instead.