### PR TITLE
Fix Pivot Step :: Add a custom stepSelectedColumn getter and setter

### DIFF
--- a/src/components/stepforms/PivotStepForm.vue
+++ b/src/components/stepforms/PivotStepForm.vue
@@ -65,6 +65,19 @@ export default class PivotStepForm extends BaseStepForm<PivotStep> {
   readonly title: string = 'Pivot column';
   aggregationFunctions: PivotStep['agg_function'][] = ['sum', 'avg', 'count', 'min', 'max'];
 
+  get stepSelectedColumn() {
+    return this.editedStep.column_to_pivot;
+  }
+
+  set stepSelectedColumn(colname: string | null) {
+    if (colname === null) {
+      throw new Error('should not try to set null on percentage "value column" field');
+    }
+    if (colname !== null) {
+      this.editedStep.column_to_pivot = colname;
+    }
+  }
+
   validate() {
     const errors = this.$$super.validate();
     if (errors !== null) {
@@ -80,9 +93,7 @@ export default class PivotStepForm extends BaseStepForm<PivotStep> {
           schemaPath: '.column_to_pivot',
           keyword: 'columnNameConflict',
           dataPath: '.column_to_pivot',
-          message: `Column name ${
-            this.editedStep.column_to_pivot
-          } is used at least twice but should be unique`,
+          message: `Column name ${this.editedStep.column_to_pivot} is used at least twice but should be unique`,
         },
       ];
     } else if (this.editedStep.index.includes(this.editedStep.value_column)) {
@@ -92,9 +103,7 @@ export default class PivotStepForm extends BaseStepForm<PivotStep> {
           schemaPath: '.value_column',
           keyword: 'columnNameConflict',
           dataPath: '.value_column',
-          message: `Column name ${
-            this.editedStep.value_column
-          } is used at least twice but should be unique`,
+          message: `Column name ${this.editedStep.value_column} is used at least twice but should be unique`,
         },
       ];
     }

--- a/tests/unit/pivot-step-form.spec.ts
+++ b/tests/unit/pivot-step-form.spec.ts
@@ -118,6 +118,20 @@ describe('Pivot Step Form', () => {
     });
   });
 
+  it('should update step when selectedColumn is changed', async () => {
+    const store = setupStore({
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+    });
+    const wrapper = shallowMount(PivotStepForm, { store, localVue });
+    expect(wrapper.vm.$data.editedStep.column_to_pivot).toEqual('');
+    store.commit('toggleColumnSelection', { column: 'columnB' });
+    await localVue.nextTick();
+    expect(wrapper.vm.$data.editedStep.column_to_pivot).toEqual('columnB');
+  });
+
   describe('Errors', () => {
     it('should fire errors when fields are missing', () => {
       const wrapper = mount(PivotStepForm, { store: emptyStore, localVue });


### PR DESCRIPTION
When a column is selected before opening the step form, we want to
mutate editedStep.column_to_pivot which was not the case before.