### PR TITLE
[getters] introduce the columnTypes getter

### DIFF
--- a/src/components/stepforms/FillnaStepForm.vue
+++ b/src/components/stepforms/FillnaStepForm.vue
@@ -25,7 +25,7 @@ import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import BaseStepForm from './StepForm.vue';
 import { FillnaStep } from '@/lib/steps';
-import { DataSetColumn } from '@/lib/dataset';
+import { ColumnTypeMapping } from '@/lib/dataset';
 import { castFromString } from '@/lib/helpers';
 
 @StepFormComponent({
@@ -40,7 +40,7 @@ export default class FillnaStepForm extends BaseStepForm<FillnaStep> {
   @Prop({ type: Object, default: () => ({ name: 'fillna', column: '', value: '' }) })
   initialStepValue!: FillnaStep;
 
-  @Getter columnHeaders!: DataSetColumn[];
+  @Getter columnTypes!: ColumnTypeMapping;
 
   readonly title: string = 'Fill null values';
 
@@ -58,7 +58,7 @@ export default class FillnaStepForm extends BaseStepForm<FillnaStep> {
   }
 
   submit() {
-    const type = this.columnHeaders.filter(h => h.name === this.editedStep.column)[0].type;
+    const type = this.columnTypes[this.editedStep.column];
     if (type !== undefined) {
       this.editedStep.value = castFromString(this.editedStep.value as string, type);
     }

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -26,7 +26,7 @@ import ListWidget from './widgets/List.vue';
 import BaseStepForm from './StepForm.vue';
 import { FilterStep, FilterComboAnd } from '@/lib/steps';
 import { FilterSimpleCondition } from '@/lib/steps';
-import { DataSetColumn } from '@/lib/dataset';
+import { ColumnTypeMapping } from '@/lib/dataset';
 import { castFromString } from '@/lib/helpers';
 
 @StepFormComponent({
@@ -47,7 +47,7 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
   })
   initialStepValue!: FilterStep;
 
-  @Getter columnHeaders!: DataSetColumn[];
+  @Getter columnTypes!: ColumnTypeMapping;
 
   readonly title: string = 'Filter';
   condition = this.initialStepValue.condition as FilterComboAnd;
@@ -73,7 +73,7 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
 
   submit() {
     for (const cond of this.editedStep.condition.and as FilterSimpleCondition[]) {
-      const type = this.columnHeaders.filter(h => h.name === cond.column)[0].type;
+      const type = this.columnTypes[cond.column];
       if (type !== undefined) {
         if (Array.isArray(cond.value)) {
           cond.value = cond.value.map(v => castFromString(v, type));

--- a/src/components/stepforms/ReplaceStepForm.vue
+++ b/src/components/stepforms/ReplaceStepForm.vue
@@ -36,7 +36,7 @@ import ListWidget from '@/components/stepforms/widgets/List.vue';
 import ReplaceWidget from '@/components/stepforms/widgets/Replace.vue';
 import BaseStepForm from './StepForm.vue';
 import { ReplaceStep } from '@/lib/steps';
-import { DataSetColumn } from '@/lib/dataset';
+import { ColumnTypeMapping } from '@/lib/dataset';
 import { castFromString } from '@/lib/helpers';
 
 @StepFormComponent({
@@ -52,7 +52,7 @@ export default class ReplaceStepForm extends BaseStepForm<ReplaceStep> {
   @Prop({ type: Object, default: () => ({ name: 'replace', search_column: '', to_replace: [[]] }) })
   initialStepValue!: ReplaceStep;
 
-  @Getter columnHeaders!: DataSetColumn[];
+  @Getter columnTypes!: ColumnTypeMapping;
 
   readonly title: string = 'Replace values';
   replaceWidget = ReplaceWidget;
@@ -81,7 +81,7 @@ export default class ReplaceStepForm extends BaseStepForm<ReplaceStep> {
   }
 
   submit() {
-    const type = this.columnHeaders.filter(h => h.name === this.editedStep.search_column)[0].type;
+    const type = this.columnTypes[this.editedStep.search_column];
     for (const tuple of this.editedStep.to_replace) {
       if (type !== undefined) {
         tuple[0] = castFromString(tuple[0], type);

--- a/src/lib/dataset/index.ts
+++ b/src/lib/dataset/index.ts
@@ -5,6 +5,9 @@
 import { PaginationContext } from './pagination';
 
 export type DataSetColumnType = 'integer' | 'float' | 'boolean' | 'string' | 'date' | 'object';
+export type ColumnTypeMapping = {
+  [col: string]: DataSetColumnType | undefined;
+};
 
 export type DataSetColumn = {
   name: string;

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -1,6 +1,7 @@
 /**
  * exports the list of store getters.
  */
+import _ from 'lodash';
 
 import { VQBState, activePipeline, inactivePipeline } from './state';
 
@@ -17,6 +18,11 @@ export default {
    * the list of dataset's column headers.
    */
   columnHeaders: (state: VQBState) => state.dataset.headers,
+  /**
+   * return a mapping { columnName → columnType }
+   */
+  columnTypes: (state: VQBState) =>
+    _.fromPairs(state.dataset.headers.map(col => [col.name, col.type])),
   /**
    * a direct "usable" index (i.e. convert "-1" to a positive one) of last active step.
    */

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -97,6 +97,27 @@ describe('getter tests', () => {
     });
   });
 
+  describe('column types tests', () => {
+    it('should return column types', () => {
+      const state = buildState({
+        dataset: {
+          headers: [
+            { name: 'col1', type: 'integer' },
+            { name: 'col2', type: 'boolean' },
+            { name: 'col3' },
+          ],
+          data: [],
+        },
+      });
+      const columnTypes = getters.columnTypes(state);
+      expect(columnTypes).toEqual({
+        col1: 'integer',
+        col2: 'boolean',
+        col3: undefined,
+      });
+    });
+  });
+
   describe('domain extraction tests', () => {
     it('should return the domain step', () => {
       const pipeline: Pipeline = [


### PR DESCRIPTION
`columnTypes` is the `columnName` → `columnType` map for the current dataset.

This will avoid lines as below to proliferate:
```
const type = this.columnHeaders.filter(h => h.name === this.editedStep.search_column)[0].type;
```

since we can now use:
```
const type = this.columnTypes[this.editedStep.search_column];
```