### PR TITLE
Feature :: catch backend error

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -99,7 +99,7 @@ async function setupInitialData(store, domain = null) {
   } else {
     const response = await mongoservice.executePipeline(store.state.pipeline, store.state.pagesize);
     if (response.error) {
-      store.commit('setBackendErrorMessage', { backendErrorMessage: response.error });
+      store.commit('setBackendError', { backendError: { type: 'error', error: response.error } });
     } else {
       store.commit('setDataset', { dataset: response.data });
     }
@@ -135,6 +135,12 @@ async function buildVueApp() {
       code: function() {
         const query = mongo36translator.translate(this.$store.getters.activePipeline);
         return JSON.stringify(query, null, 2);
+      },
+      thereIsABackendError: function() {
+        return this.$store.getters.thereIsABackendError;
+      },
+      backendErrorMessage: function() {
+        return this.$store.getters.backendErrorMessage;
       },
     },
     methods: {

--- a/playground/dist/index.html
+++ b/playground/dist/index.html
@@ -69,6 +69,15 @@
         height: 40px;
         font-size: 20px;
       }
+
+      .error-message {
+        position: absolute;
+        right: 0;
+        top: 0;
+        background: red;
+        color: white;
+        padding: 10px;
+      }
     </style>
   </head>
 
@@ -87,6 +96,9 @@
         Hide code
       </button>
       <pre v-show="isCodeOpened"><code>{{ code }}</code></pre>
+      <div class="error-message" v-if="thereIsABackendError">
+        <i class="fas fa-exclamation-triangle"></i> {{ backendErrorMessage }}
+      </div>
     </div>
     <!-- built files will be auto injected -->
     <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>

--- a/playground/server.js
+++ b/playground/server.js
@@ -84,18 +84,21 @@ function assertIsConnected(client, err) {
  */
 function facetize(query) {
   if (!query.length) {
-    query.push({ $match: {} })
+    query.push({ $match: {} });
   }
   return [
     {
       $facet: {
-        stage1: [{
-          $group: {
-            _id: null, count: { $sum: 1 }
-          }
-        }],
+        stage1: [
+          {
+            $group: {
+              _id: null,
+              count: { $sum: 1 },
+            },
+          },
+        ],
         stage2: query,
-      }
+      },
     },
 
     { $unwind: '$stage1' },
@@ -104,9 +107,9 @@ function facetize(query) {
     {
       $project: {
         count: '$stage1.count',
-        data: '$stage2'
-      }
-    }
+        data: '$stage2',
+      },
+    },
   ];
 }
 
@@ -179,14 +182,12 @@ function setupApp(config) {
   app.use(bodyParser.json());
 
   app.post('/query', (req, res) => {
-    executeQuery(
-      config,
-      client,
-      req.body.collection,
-      req.body.query,
-      res.json.bind(res),
-      console.error,
-    );
+    executeQuery(config, client, req.body.collection, req.body.query, res.json.bind(res), function(
+      err,
+    ) {
+      res.status(400).send(err);
+      console.error(err);
+    });
   });
 
   app.post('/load', upload.single('file'), (req, res) => {

--- a/src/lib/backend-response.ts
+++ b/src/lib/backend-response.ts
@@ -1,0 +1,10 @@
+type BackendErrorType = 'error' | 'warning';
+
+export type BackendError = {
+  type: BackendErrorType;
+  message: string;
+};
+
+export type BackendResponse<T> =
+  | Promise<{ data: T; error?: never }>
+  | Promise<{ data?: never; error: BackendError }>;

--- a/src/store/backend-plugin.ts
+++ b/src/store/backend-plugin.ts
@@ -37,21 +37,21 @@ export interface BackendService {
 
 async function _updateDataset(store: Store<VQBState>, service: BackendService, pipeline: Pipeline) {
   try {
-    const reponse = await service.executePipeline(
+    const response = await service.executePipeline(
       pipeline,
       store.state.pagesize,
       pageOffset(store.state.pagesize, store.getters.pageno),
     );
-    if (reponse.error) {
-      store.commit('setBackendErrorMessage', { backendErrorMessage: reponse.error });
+    if (response.error) {
+      store.commit('setBackendError', { backendError: { type: 'error', message: response.error } });
     } else {
-      store.commit('setDataset', { dataset: reponse.data });
-      // restore message error to null:
-      store.commit('setBackendErrorMessage', { backendErrorMessage: null });
+      store.commit('setDataset', { dataset: response.data });
+      // reset backend error to undefined:
+      store.commit('setBackendError', { backendError: undefined });
     }
   } catch (error) {
-    store.commit('setBackendErrorMessage', {
-      backendErrorMessage: { type: 'error', message: error },
+    store.commit('setBackendError', {
+      backendError: { type: 'error', message: error },
     });
   }
 }

--- a/src/store/backend-plugin.ts
+++ b/src/store/backend-plugin.ts
@@ -9,7 +9,8 @@
  */
 import { Store } from 'vuex';
 
-import { DataSet } from '@/lib/dataset';
+import { BackendResponse } from '@/lib/backend-response';
+import { DataSet } from '@/lib/dataset'
 import { Pipeline } from '@/lib/steps';
 
 import { StateMutation } from './mutations';
@@ -20,7 +21,7 @@ export interface BackendService {
   /**
    * @return a promise that holds the list of available collections
    */
-  listCollections(): Promise<string[]>;
+  listCollections(): BackendResponse<string[]>;
   /**
    * @param pipeline the pipeline to translate and execute on the backend
    * @param limit if specified, a limit to be applied on the results. How is limit
@@ -31,7 +32,7 @@ export interface BackendService {
    * @return a promise that holds the result of the pipeline execution,
    * formatted as as `DataSet`
    */
-  executePipeline(pipeline: Pipeline, limit: number, offset: number): Promise<DataSet>;
+  executePipeline(pipeline: Pipeline, limit: number, offset: number): BackendResponse<DataSet>;
 }
 
 async function _updateDataset(store: Store<VQBState>, service: BackendService, pipeline: Pipeline) {

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -63,4 +63,8 @@ export default {
    */
   pageno: (state: VQBState) =>
     state.dataset.paginationContext ? state.dataset.paginationContext.pageno : 1,
+  /**
+   * Return true if an error occured in the backend
+   */
+  thereIsABackendError: (state: VQBState) => state.backendErrorMessage !== null,
 };

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -10,6 +10,12 @@ export default {
    * the part of the pipeline that is currently selected.
    */
   activePipeline,
+
+  /**
+   * current backend's error message
+   */
+  backendErrorMessage: (state: VQBState) =>
+    state.backendError ? state.backendError.message : null,
   /**
    * the list of current dataset's colum names.
    **/
@@ -66,5 +72,5 @@ export default {
   /**
    * Return true if an error occured in the backend
    */
-  thereIsABackendError: (state: VQBState) => state.backendErrorMessage !== null,
+  thereIsABackendError: (state: VQBState) => state.backendError !== undefined,
 };

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -6,6 +6,11 @@ import { DomainStep } from '@/lib/steps';
 import { VQBState } from './state';
 
 // provide types for each possible mutations' payloads
+type BackendErrorMutation = {
+  type: 'setBackendErrorMessage';
+  payload: Pick<VQBState, 'backendErrorMessage'>;
+};
+
 type DatasetMutation = {
   type: 'setDataset';
   payload: Pick<VQBState, 'dataset'>;
@@ -52,6 +57,7 @@ type ToggleColumnSelectionMutation = {
 };
 
 export type StateMutation =
+  | BackendErrorMutation
   | DatasetMutation
   | DeleteStepMutation
   | DomainsMutation
@@ -156,5 +162,12 @@ export default {
       const length = state.dataset.data.length;
       state.dataset.paginationContext = { pageno, pagesize: length, totalCount: length };
     }
+  },
+
+  /**
+   * update backendErrorMessage.
+   */
+  setBackendErrorMessage(state: VQBState, { backendErrorMessage }: Pick<VQBState, 'backendErrorMessage'>) {
+    state.backendErrorMessage = backendErrorMessage;
   },
 };

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -7,8 +7,8 @@ import { VQBState } from './state';
 
 // provide types for each possible mutations' payloads
 type BackendErrorMutation = {
-  type: 'setBackendErrorMessage';
-  payload: Pick<VQBState, 'backendErrorMessage'>;
+  type: 'setBackendError';
+  payload: Pick<VQBState, 'backendError'>;
 };
 
 type DatasetMutation = {
@@ -167,7 +167,7 @@ export default {
   /**
    * update backendErrorMessage.
    */
-  setBackendErrorMessage(state: VQBState, { backendErrorMessage }: Pick<VQBState, 'backendErrorMessage'>) {
-    state.backendErrorMessage = backendErrorMessage;
+  setBackendError(state: VQBState, { backendError }: Pick<VQBState, 'backendError'>) {
+    state.backendError = backendError;
   },
 };

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -3,6 +3,7 @@
  */
 import { DataSet } from '@/lib/dataset';
 import { Pipeline } from '@/lib/steps';
+import { BackendError } from '@/lib/backend-response';
 
 export interface VQBState {
   /**
@@ -40,6 +41,11 @@ export interface VQBState {
    * pagination size (i.e. number of results displayed)
    */
   pagesize: number;
+
+  /**
+   * error message send by backend or catch from its interface
+   */
+  backendErrorMessage: BackendError | null;
 }
 
 /**
@@ -62,6 +68,7 @@ export const emptyState: VQBState = {
   selectedColumns: [],
   isEditingStep: false,
   pagesize: 50,
+  backendErrorMessage: null,
 };
 
 /**

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -43,9 +43,9 @@ export interface VQBState {
   pagesize: number;
 
   /**
-   * error message send by backend or catch from its interface
+   * error send by backend or catch from its interface
    */
-  backendErrorMessage: BackendError | null;
+  backendError?: BackendError;
 }
 
 /**
@@ -68,7 +68,7 @@ export const emptyState: VQBState = {
   selectedColumns: [],
   isEditingStep: false,
   pagesize: 50,
-  backendErrorMessage: null,
+  backendError: undefined,
 };
 
 /**

--- a/tests/unit/pagination-component.spec.ts
+++ b/tests/unit/pagination-component.spec.ts
@@ -13,12 +13,12 @@ const executePipelineMock = jest.fn();
 
 class DummyService implements BackendService {
   listCollections() {
-    return Promise.resolve(['foo', 'bar']);
+    return Promise.resolve({ data: ['foo', 'bar'] });
   }
 
   executePipeline(_pipeline: Pipeline, limit: number, offset: number) {
     executePipelineMock(limit, offset);
-    return Promise.resolve({ headers: [], data: [] });
+    return Promise.resolve({ data: { headers: [], data: [] } });
   }
 }
 

--- a/tests/unit/plugins.spec.ts
+++ b/tests/unit/plugins.spec.ts
@@ -13,7 +13,7 @@ localVue.use(Vuex);
 
 class DummyService implements BackendService {
   listCollections() {
-    return Promise.resolve(['foo', 'bar']);
+    return Promise.resolve({ data: ['foo', 'bar'] });
   }
 
   // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
@@ -23,8 +23,10 @@ class DummyService implements BackendService {
       rset = rset.slice(0, limit);
     }
     return Promise.resolve({
-      headers: [{ name: 'x' }, { name: 'y' }],
-      data: rset,
+      data: {
+        headers: [{ name: 'x' }, { name: 'y' }],
+        data: rset,
+      },
     });
   }
 }

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -194,13 +194,13 @@ describe('getter tests', () => {
   });
 
   describe('message error related test', () => {
-    it('should return false if backendErrorMessage is null', () => {
-      const state = buildState({ backendErrorMessage: null });
+    it('should return false if backendError is undefined', () => {
+      const state = buildState({ backendError: undefined });
       expect(getters.thereIsABackendError(state)).toBeFalsy();
     });
 
-    it('should return true if backendErrorMessage is not null', () => {
-      const state = buildState({ backendErrorMessage: { type: 'error', message: 'error msg' } });
+    it('should return true if backendError is not undefined', () => {
+      const state = buildState({ backendError: { type: 'error', message: 'error msg' } });
       expect(getters.thereIsABackendError(state)).toBeTruthy();
     });
   });
@@ -309,11 +309,11 @@ describe('mutation tests', () => {
     expect(state.selectedColumns).toEqual([]);
   });
 
-  it('set a backend error message', () => {
+  it('set a backend error', () => {
     const state = buildState({});
-    mutations.setBackendErrorMessage(state, {
-      backendErrorMessage: { type: 'error', message: 'error msg' },
+    mutations.setBackendError(state, {
+      backendError: { type: 'error', message: 'error msg' },
     });
-    expect(state.backendErrorMessage).toEqual({ type: 'error', message: 'error msg' });
+    expect(state.backendError).toEqual({ type: 'error', message: 'error msg' });
   });
 });

--- a/tests/unit/store.spec.ts
+++ b/tests/unit/store.spec.ts
@@ -192,6 +192,18 @@ describe('getter tests', () => {
       expect(getters.isStepDisabled(state)(3)).toBeTruthy();
     });
   });
+
+  describe('message error related test', () => {
+    it('should return false if backendErrorMessage is null', () => {
+      const state = buildState({ backendErrorMessage: null });
+      expect(getters.thereIsABackendError(state)).toBeFalsy();
+    });
+
+    it('should return true if backendErrorMessage is not null', () => {
+      const state = buildState({ backendErrorMessage: { type: 'error', message: 'error msg' } });
+      expect(getters.thereIsABackendError(state)).toBeTruthy();
+    });
+  });
 });
 
 describe('mutation tests', () => {
@@ -295,5 +307,13 @@ describe('mutation tests', () => {
     const state = buildState({});
     mutations.setSelectedColumns(state, { column: undefined });
     expect(state.selectedColumns).toEqual([]);
+  });
+
+  it('set a backend error message', () => {
+    const state = buildState({});
+    mutations.setBackendErrorMessage(state, {
+      backendErrorMessage: { type: 'error', message: 'error msg' },
+    });
+    expect(state.backendErrorMessage).toEqual({ type: 'error', message: 'error msg' });
   });
 });


### PR DESCRIPTION
# Descrition
**Before:** when a backend error occurred nothing happens. The user had no feedback or debug message.
**Now:** we catch backend error and store the last error message in the vuex store.

# What does this PR introduce ?
To do so, we introduce a new backend response format call `BackendResponse` and implemented in `lib/backend-response.ts`. 

**Before:** There was two possible backend responses: 
- list of string --> from `listCollection`
- Dataset --> from `executePipeline`

**Now:** All backend responses have the same "meta" format. It must be a object with two fields uncompatible fields:
   - `data` can be of type `DataSet` (from `executePipeline`) or list of string (from `executePipeline`)
   - `error` must be of type `ErrorResponse`

If the response has field `'error'` we now commit in the store a new state properties: `backendErrorMessage`.
NB : if no error, then `backendErrorMessage` is `null`

Finally we use this new properties to display the message in the template. Need design for the integration.


⚠️ this PR is not tested yet


# Screenshot and additional info

<img width="1436" alt="vue-query-builder" src="https://user-images.githubusercontent.com/15191323/62356994-7d6f5d80-b512-11e9-8dd2-c94cbe5acd8c.png">


