### PR TITLE
Feature :: pagination counter (clean branch)

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -34,7 +34,7 @@ class MongoService {
     dataset.paginationContext = {
       totalCount: count,
       pagesize: limit,
-      pageno: Math.floor(offset / limit),
+      pageno: Math.floor(offset / limit) + 1,
     }
     const datasetWithInferedType = inferTypeFromDataset(dataset);
     return datasetWithInferedType;

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -7,6 +7,11 @@
       next-class="prevnext"
       :clickHandler="pageClicked"
     />
+    <div class="pagination-counter">
+      <span class="pagination-counter__current-min">{{ pageRows.min }}</span>
+      <span class="pagination-counter__current-max">&nbsp;- {{ pageRows.max }}</span>
+      <span class="pagination-counter__total-count">&nbsp;of {{ totalCount }} rows</span>
+    </div>
   </div>
 </template>
 
@@ -15,7 +20,7 @@ import Paginate from 'vuejs-paginate';
 import { Vue, Component } from 'vue-property-decorator';
 import { Mutation, State } from 'vuex-class';
 import { DataSet } from '@/lib/dataset';
-import { numberOfPages } from '@/lib/dataset/pagination';
+import { numberOfPages, pageOffset, pageMinMax } from '@/lib/dataset/pagination';
 import { MutationCallbacks } from '@/store/mutations';
 
 @Component({
@@ -34,6 +39,19 @@ export default class Pagination extends Vue {
       return numberOfPages(this.dataset.paginationContext);
     }
     return 1;
+  }
+
+  get totalCount() {
+    if (this.dataset.paginationContext) {
+      return this.dataset.paginationContext.totalCount;
+    }
+  }
+
+  get pageRows() {
+    if (this.dataset.paginationContext) {
+      return pageMinMax(this.dataset.paginationContext);
+    }
+    return 0;
   }
 
   pageClicked(pageno: number) {
@@ -82,5 +100,13 @@ export default class Pagination extends Vue {
   background-color: #2665a3;
   color: #fff;
   cursor: not-allowed;
+}
+.pagination-counter {
+  background: #999;
+  bottom: 0;
+  color: #fff;
+  display: flex;
+  padding: 4px 10px;
+  position: absolute;
 }
 </style>

--- a/src/lib/dataset/pagination.ts
+++ b/src/lib/dataset/pagination.ts
@@ -24,3 +24,24 @@ export function numberOfPages(paginationContext: PaginationContext) {
 export function pageOffset(pagesize: number, pageno: number) {
   return Math.max(pageno - 1, 0) * pagesize;
 }
+
+/**
+ * Get page min/max row
+ */
+export function pageMinMax(paginationContext: PaginationContext) {
+  const pageRowMin = pageOffset(
+    paginationContext.pagesize,
+    paginationContext.pageno,
+  );
+  let pageRowMax;
+  if (paginationContext.pageno === numberOfPages(paginationContext)) {
+    pageRowMax = paginationContext.totalCount
+  } else {
+    pageRowMax = pageRowMin + paginationContext.pagesize;
+  }
+  const pageRows = {
+    min: pageRowMin + 1,
+    max: pageRowMax,
+  }
+  return pageRows;
+}

--- a/tests/unit/pagination-component.spec.ts
+++ b/tests/unit/pagination-component.spec.ts
@@ -81,4 +81,22 @@ describe('Pagination Component', () => {
     // click on "page 3" ⇒ offset = 4, limit = 2
     expect(executePipelineMock).toHaveBeenCalledWith(pagesize, pagesize * 2);
   });
+
+  it('should instantiate the counter', () => {
+    const store = setupStore({
+      dataset: {
+        headers: [{ name: 'city' }, { name: 'population' }, { name: 'isCapitalCity' }],
+        data: [['Paris', 10000000, true], ['Marseille', 3000000, false]],
+        paginationContext: {
+          totalCount: 7,
+          pageno: 1,
+          pagesize: 2,
+        },
+      },
+      pagesize: 2,
+    });
+    const wrapper = mount(Pagination, { localVue, store });
+    const wrapperCounter = wrapper.find('.pagination-counter');
+    expect(wrapperCounter.exists()).toBeTruthy();
+  });
 });

--- a/tests/unit/pagination.spec.ts
+++ b/tests/unit/pagination.spec.ts
@@ -24,4 +24,40 @@ describe('pagination tests', () => {
     expect(P.pageOffset(20, 1)).toEqual(0);
     expect(P.pageOffset(20, 2)).toEqual(20);
   });
+
+  it('should return correctly the min and max row of a page offset on the first page', () => {
+    const context: P.PaginationContext = {
+      pageno: 1,
+      pagesize: 20,
+      totalCount: 208,
+    };
+    expect(P.pageMinMax(context)).toEqual({ min: 1, max: 20 });
+  });
+
+  it('should return last page of pagination', () => {
+    const context: P.PaginationContext = {
+      pageno: 0,
+      pagesize: 50,
+      totalCount: 100,
+    };
+    expect(P.numberOfPages(context)).toEqual(2);
+  });
+
+  it('should return correctly the min and max row of a page offset on the last page', () => {
+    const context: P.PaginationContext = {
+      pageno: 2,
+      pagesize: 50,
+      totalCount: 100,
+    };
+    expect(P.pageMinMax(context)).toEqual({ min: 51, max: 100 });
+  });
+
+  it('should return correctly the min and max row of a page offset on the last page with total count less than the page count', () => {
+    const context: P.PaginationContext = {
+      pageno: 11,
+      pagesize: 20,
+      totalCount: 208,
+    };
+    expect(P.pageMinMax(context)).toEqual({ min: 201, max: 208 });
+  });
 });


### PR DESCRIPTION
add a counter to pagination component with three informations :
- page current min row => first row number which is displayed in the current page
- page current max row => last row number which is displayed in the current page
- row total rows 

At the last page `page current max row` is hidden.

![image](https://user-images.githubusercontent.com/4438175/62369283-6b4fe800-b52f-11e9-9b01-329955f3ffa9.png)

