### PR TITLE
Make formula step accessible from compute widget

### DIFF
--- a/src/components/ActionToolbar.vue
+++ b/src/components/ActionToolbar.vue
@@ -1,14 +1,6 @@
 <template>
   <div class="action-toolbar__container">
     <div class="action-toolbar">
-      <button
-        type="button"
-        class="action-toolbar__btn action-toolbar__btn--special"
-        @click="actionClicked('formula')"
-      >
-        <i class="action-toolbar__btn-icon fas fa-plus"></i>
-        <span class="action-toolbar__btn-txt">Column</span>
-      </button>
       <action-toolbar-button
         v-for="(button, index) in formattedButtons"
         :icon="button.icon"

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -14,7 +14,7 @@
   </div>
 </template>
 <script lang="ts">
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { Component, Vue } from 'vue-property-decorator';
 import { groupActions, SEARCH_ACTION } from './constants';
 import Multiselect from 'vue-multiselect';
 

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -23,7 +23,10 @@ export type groupActions = {
 };
 
 export const ACTION_CATEGORIES: ActionCategories = {
-  compute: [{ name: 'percentage', label: 'Percentage of total' }],
+  compute: [
+    { name: 'formula', label: 'Formula' },
+    { name: 'percentage', label: 'Percentage of total' },
+  ],
   filter: [
     { name: 'delete', label: 'Delete columns' },
     { name: 'select', label: 'Keep columns' },
@@ -37,19 +40,12 @@ export const ACTION_CATEGORIES: ActionCategories = {
 
 export const SEARCH_ACTION: groupActions[] = [
   {
-    type: 'compute',
-    actions: [{ name: 'percentage', label: 'Percentage of total' }],
+    type: 'filter',
+    actions: [...ACTION_CATEGORIES.filter],
   },
   {
-    type: 'filter',
-    actions: [
-      { name: 'delete', label: 'Delete columns' },
-      { name: 'select', label: 'Keep columns' },
-      { name: 'filter', label: 'Filter based on conditions' },
-      { name: 'top', label: 'Top N rows' },
-      { name: 'argmax', label: 'Argmax' },
-      { name: 'argmin', label: 'Argmin' },
-    ],
+    type: 'compute',
+    actions: [...ACTION_CATEGORIES.compute],
   },
   {
     type: 'aggregate',
@@ -62,7 +58,7 @@ export const SEARCH_ACTION: groupActions[] = [
   },
   {
     type: 'reshape',
-    actions: [{ name: 'pivot', label: 'Pivot' }, { name: 'unpivot', label: 'Unpivot' }],
+    actions: [...ACTION_CATEGORIES.reshape],
   },
   {
     type: 'Others action',
@@ -70,7 +66,8 @@ export const SEARCH_ACTION: groupActions[] = [
       { name: 'duplicate', label: 'Duplicate column' },
       { name: 'rename', label: 'Rename column' },
       { name: 'fillna', label: 'Fill null values' },
-      { name: 'filter', label: 'Filter values' },
+      { name: 'replace', label: 'Replace values' },
+      { name: 'sort', label: 'Sort values' },
     ],
   },
 ];

--- a/tests/unit/search-bar.spec.ts
+++ b/tests/unit/search-bar.spec.ts
@@ -16,7 +16,7 @@ describe('SearchBar', () => {
     const wrapper = mount(SearchBar, {
       propsData: {
         type: 'compute',
-        actions: [{ name: 'percentage', label: 'Percentage of total' }],
+        actions: [{ name: 'delete', label: 'Delete columns' }],
       },
     });
     const multiselect = wrapper.findAll('.multiselect__option');
@@ -25,13 +25,13 @@ describe('SearchBar', () => {
         .at(1)
         .find('span span')
         .text(),
-    ).toEqual('Percentage of total');
+    ).toEqual('Delete columns');
   });
 
   it('should emit "actionClicked" when an option multiselect is clicked', () => {
     const wrapper = mount(SearchBar);
     const multiselectOption = wrapper.findAll('.multiselect__option');
     multiselectOption.at(1).trigger('click');
-    expect(wrapper.emitted().actionClicked[0]).toEqual(['percentage']);
+    expect(wrapper.emitted().actionClicked[0]).toEqual(['delete']);
   });
 });


### PR DESCRIPTION
Make formula step accessible from compute widget and from search bar
Therefore we get rid of the widget '+ column' which was less
intuitive and took some unnecessary space in the toolbar.
At the same time, we propose an enhancement of the SEARCH_BAR
constant definition to reflect its dependancy on the
ACTION_CATEGORIES constant definition