### PR TITLE
Fix : Filter step US

### DIFF
--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="widget-autocomplete__container">
-    <label class="widget-autocomplete__label" :for="id">{{ name }}</label>
+    <label class="widget-autocomplete__label" v-if="name" :for="id">{{ name }}</label>
     <multiselect
       v-model="editedValue"
       :options="options"

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -99,6 +99,12 @@ export default class AutocompleteWidget extends Vue {
   font-size: 14px;
   margin-bottom: 0;
 }
+
+.widget-autocomplete__container .multiselect__content-wrapper {
+  min-width: 100%;
+  width: auto;
+}
+
 .multiselect__single,
 .multiselect__input {
   padding-left: 0;

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -41,8 +41,8 @@ type LiteralOperator =
   | 'be greater than or equal to'
   | 'be less than'
   | 'be less than or equal to'
-  | 'be among'
-  | 'not be among';
+  | 'be one of'
+  | 'not be one of';
 
 type ShortOperator = FilterSimpleCondition['operator'];
 
@@ -79,8 +79,8 @@ export default class FilterSimpleConditionWidget extends Vue {
     { operator: 'ge', label: 'be greater than or equal to', inputWidget: InputTextWidget },
     { operator: 'lt', label: 'be less than', inputWidget: InputTextWidget },
     { operator: 'le', label: 'be less than or equal to', inputWidget: InputTextWidget },
-    { operator: 'in', label: 'be among', inputWidget: MultiInputTextWidget },
-    { operator: 'nin', label: 'not be among', inputWidget: MultiInputTextWidget },
+    { operator: 'in', label: 'be one of', inputWidget: MultiInputTextWidget },
+    { operator: 'nin', label: 'not be one of', inputWidget: MultiInputTextWidget },
   ];
 
   readonly placeholder = 'Enter a value';

--- a/src/components/stepforms/widgets/InputText.vue
+++ b/src/components/stepforms/widgets/InputText.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="widget-input-text__container">
-    <label :for="id">{{name}}</label>
+    <label v-if="name" :for="id">{{name}}</label>
     <input
       :id="id"
       :class="elementClass"

--- a/tests/unit/autocomplete-widget.spec.ts
+++ b/tests/unit/autocomplete-widget.spec.ts
@@ -11,4 +11,15 @@ describe('Widget Autocomplete', () => {
     const wrapper = shallowMount(AutocompleteWidget);
     expect(wrapper.find('multiselect-stub').exists()).toBeTruthy();
   });
+
+  it('should have a label if prop "name" is defined', () => {
+    const wrapper = shallowMount(AutocompleteWidget, { propsData: { name: 'foo' } });
+    const labelWrapper = wrapper.find('label');
+    expect(labelWrapper.text()).toEqual('foo');
+  });
+
+  it('should not have a label if prop "name" is undefined', () => {
+    const wrapper = shallowMount(AutocompleteWidget);
+    expect(wrapper.find('label').exists()).toBeFalsy();
+  });
 });

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -63,7 +63,7 @@ describe('Widget AggregationWidget', () => {
     const widgetWrappers = wrapper.findAll('autocompletewidget-stub');
     expect(widgetWrappers.at(1).props().value).toEqual({
       operator: 'nin',
-      label: 'not be among',
+      label: 'not be one of',
       inputWidget: MultiInputTextWidget,
     });
   });
@@ -73,7 +73,7 @@ describe('Widget AggregationWidget', () => {
     expect((wrapper.vm.$data.editedValue.value = ''));
     wrapper.setData({ editedValue: { column: 'foo', value: [], operator: 'in' } });
     const operatorWrapper = wrapper.findAll('autocompletewidget-stub').at(1);
-    await operatorWrapper.trigger('input', { value: 'be among' });
+    await operatorWrapper.trigger('input', { value: 'be one of' });
     expect((wrapper.vm.$data.editedValue.value = []));
   });
 

--- a/tests/unit/input-text-widget.spec.ts
+++ b/tests/unit/input-text-widget.spec.ts
@@ -15,21 +15,14 @@ describe('Widget Input Text', () => {
     expect(wrapper.find("input[type='text']").exists()).toBeTruthy();
   });
 
-  it('should have an empty label', () => {
+  it('should not have a label if prop "name" is undefined', () => {
     const wrapper = shallowMount(InputTextWidget);
-    const labelWrapper = wrapper.find('label');
-
-    expect(labelWrapper.text()).toEqual('');
+    expect(wrapper.find('label').exists()).toBeFalsy();
   });
 
-  it('should have a label', () => {
-    const wrapper = shallowMount(InputTextWidget, {
-      propsData: {
-        name: 'Stark',
-      },
-    });
+  it('should have a label if prop "name" is defined', () => {
+    const wrapper = shallowMount(InputTextWidget, { propsData: { name: 'Stark' } });
     const labelWrapper = wrapper.find('label');
-
     expect(labelWrapper.text()).toEqual('Stark');
   });
 


### PR DESCRIPTION
- Do not render an empty label element in html of Autocomplete and InputText components to avoid alignment issues
- Make the autocomplete menu width to fit to the longest label size
- Change non intuitive labels for filter operators: "(not) be among" => "(not) be one of"