### PR TITLE
Feature :: Improve display error message

### DIFF
--- a/src/components/stepforms/AggregateStepForm.vue
+++ b/src/components/stepforms/AggregateStepForm.vue
@@ -8,6 +8,8 @@
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.on[editedStep.on.length-1] })"
       placeholder="Add columns"
+      data-path=".on"
+      :errors="errors"
     ></MultiselectWidget>
     <ListWidget
       addFieldName="Add aggregation"
@@ -17,8 +19,10 @@
       :defaultItem="defaultAggregation"
       :widget="widgetAggregation"
       :automatic-new-field="false"
+      data-path=".aggregations"
+      :errors="errors"
     ></ListWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/ArgmaxStepForm.vue
+++ b/src/components/stepforms/ArgmaxStepForm.vue
@@ -6,6 +6,8 @@
       v-model="editedStep.column"
       name="Search min value in..."
       placeholder="Enter a column name"
+      data-path=".column"
+      :errors="errors"
     ></ColumnPicker>
     <MultiselectWidget
       id="groupbyColumnsInput"
@@ -14,8 +16,10 @@
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.groups[editedStep.groups.length-1] })"
       placeholder="Add columns"
+      data-path=".groups"
+      :errors="errors"
     ></MultiselectWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/ArgminStepForm.vue
+++ b/src/components/stepforms/ArgminStepForm.vue
@@ -6,6 +6,8 @@
       v-model="editedStep.column"
       name="Search min value in..."
       placeholder="Enter a column name"
+      data-path=".column"
+      :errors="errors"
     ></ColumnPicker>
     <MultiselectWidget
       id="groupbyColumnsInput"
@@ -14,8 +16,10 @@
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.groups[editedStep.groups.length-1] })"
       placeholder="Add columns"
+      data-path=".groups"
+      :errors="errors"
     ></MultiselectWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/ColumnPicker.vue
+++ b/src/components/stepforms/ColumnPicker.vue
@@ -6,6 +6,8 @@
     :options="columnNames"
     @input="valueChanged"
     :placeholder="placeholder"
+    :data-path="dataPath"
+    :errors="errors"
   ></AutocompleteWidget>
 </template>
 
@@ -16,6 +18,7 @@ import { Component, Prop, Watch } from 'vue-property-decorator';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import { Getter, Mutation } from 'vuex-class';
 import { MutationCallbacks } from '@/store/mutations';
+import { ErrorObject } from 'ajv';
 
 @Component({ components: { AutocompleteWidget } })
 export default class ColumnPicker extends Vue {
@@ -30,6 +33,12 @@ export default class ColumnPicker extends Vue {
 
   @Prop({ type: String, default: null })
   initialColumn!: string | null;
+
+  @Prop({ type: Array, default: () => [] })
+  errors!: ErrorObject[];
+
+  @Prop({ default: null })
+  dataPath!: string;
 
   // Only manage the deletion of 1 column at once at this stage
   column: string | null = null;

--- a/src/components/stepforms/DeleteColumnStepForm.vue
+++ b/src/components/stepforms/DeleteColumnStepForm.vue
@@ -8,8 +8,10 @@
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.columns[editedStep.columns.length-1] })"
       placeholder="Add columns"
+      data-path=".columns"
+      :errors="errors"
     ></MultiselectWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/DuplicateColumnStepForm.vue
+++ b/src/components/stepforms/DuplicateColumnStepForm.vue
@@ -6,14 +6,18 @@
       v-model="editedStep.column"
       name="Duplicate column..."
       placeholder="Enter a column"
+      data-path=".column"
+      :errors="errors"
     ></ColumnPicker>
     <InputTextWidget
       id="newColumnNameInput"
       v-model="editedStep.new_column_name"
       name="New column name:"
       placeholder="Enter a column name"
+      data-path=".new_column_name"
+      :errors="errors"
     ></InputTextWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/FillnaStepForm.vue
+++ b/src/components/stepforms/FillnaStepForm.vue
@@ -6,14 +6,18 @@
       id="columnInput"
       name="Replace null values in..."
       placeholder="Enter a column"
+      data-path=".column"
+      :errors="errors"
     ></ColumnPicker>
     <InputTextWidget
       id="valueInput"
       v-model="editedStep.value"
       name="With..."
       placeholder="Enter a value"
+      data-path=".value"
+      :errors="errors"
     ></InputTextWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="filter-form">
     <step-form-title :title="title"></step-form-title>
     <div class="filter-form-headers__container">
       <div class="filter-form-header">Values in...</div>
@@ -12,8 +12,10 @@
       :defaultItem="defaultCondition"
       :widget="widgetFilterSimpleCondition"
       :automatic-new-field="false"
+      data-path=".condition.and"
+      :errors="errors"
     ></ListWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 
@@ -96,5 +98,10 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
   font-size: 14px;
   margin-left: 10px;
   width: 50%;
+}
+</style>
+<style lang="scss">
+.filter-form .widget-list__body .widget-list__icon {
+  top: 5px;
 }
 </style>

--- a/src/components/stepforms/FormulaStepForm.vue
+++ b/src/components/stepforms/FormulaStepForm.vue
@@ -1,14 +1,23 @@
 <template>
   <div>
     <step-form-title :title="title"></step-form-title>
-    <InputTextWidget id="formulaInput" v-model="editedStep.formula" name="Formula:" placeholder></InputTextWidget>
+    <InputTextWidget
+      id="formulaInput"
+      v-model="editedStep.formula"
+      name="Formula:"
+      placeholder
+      data-path=".formula"
+      :errors="errors">
+    </InputTextWidget>
     <InputTextWidget
       id="newColumnInput"
       v-model="editedStep.new_column"
       name="New colum:"
       placeholder="Enter a new column name"
-    ></InputTextWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+      data-path=".new_column"
+      :errors="errors">
+    </InputTextWidget>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/PercentageStepForm.vue
+++ b/src/components/stepforms/PercentageStepForm.vue
@@ -6,6 +6,8 @@
       v-model="editedStep.column"
       name="Value column..."
       placeholder="Enter a column"
+      data-path=".column"
+      :errors="errors"
     ></ColumnPicker>
     <MultiselectWidget
       id="groupbyColumnsInput"
@@ -13,14 +15,18 @@
       name="(Optional) Group by..."
       :options="columnNames"
       placeholder="Add columns"
+      data-path=".group"
+      :errors="errors"
     ></MultiselectWidget>
     <InputTextWidget
       id="newColumnNameInput"
       v-model="editedStep.new_column"
       name="(Optional) New column name..."
       placeholder="Enter a new column name"
+      data-path=".new_column"
+      :errors="errors"
     ></InputTextWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/PivotStepForm.vue
+++ b/src/components/stepforms/PivotStepForm.vue
@@ -7,12 +7,16 @@
       name="Keep columns..."
       :options="columnNames"
       placeholder="Add columns"
+      data-path=".index"
+      :errors="errors"
     ></MultiselectWidget>
     <ColumnPicker
       id="columnToPivotInput"
       v-model="editedStep.column_to_pivot"
       name="Pivot column..."
       placeholder="Enter a column"
+      data-path=".column_to_pivot"
+      :errors="errors"
     ></ColumnPicker>
     <AutocompleteWidget
       id="valueColumnInput"
@@ -20,6 +24,8 @@
       name="Use values in..."
       :options="columnNames"
       placeholder="Select a column"
+      data-path=".value_column"
+      :errors="errors"
     ></AutocompleteWidget>
     <AutocompleteWidget
       id="aggregationFunctionInput"
@@ -27,8 +33,10 @@
       name="Aggregate values using..."
       :options="aggregationFunctions"
       placeholder="Aggregation function"
+      data-path=".agg_function"
+      :errors="errors"
     ></AutocompleteWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 <script lang="ts">

--- a/src/components/stepforms/RenameStepForm.vue
+++ b/src/components/stepforms/RenameStepForm.vue
@@ -6,14 +6,18 @@
       id="oldnameInput"
       name="Old name"
       placeholder="Enter the old column name"
+      data-path=".oldname"
+      :errors="errors"
     ></ColumnPicker>
     <InputTextWidget
       id="newnameInput"
       v-model="editedStep.newname"
       name="By..."
       placeholder="Enter a new column name"
+      data-path=".newname"
+      :errors="errors"
     ></InputTextWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/ReplaceStepForm.vue
+++ b/src/components/stepforms/ReplaceStepForm.vue
@@ -6,12 +6,16 @@
       v-model="editedStep.search_column"
       name="Search in column..."
       placeholder="Enter a column"
+      data-path=".search_column"
+      :errors="errors"
     ></ColumnPicker>
     <InputTextWidget
       id="newColumnInput"
       v-model="editedStep.new_column"
       name="(Optional) Write output in..."
       placeholder="Enter a new column name"
+      data-path=".new_column"
+      :errors="errors"
     ></InputTextWidget>
     <ListWidget
       addFieldName="Add a value to replace"
@@ -21,8 +25,10 @@
       :defaultItem="[]"
       :widget="replaceWidget"
       :automatic-new-field="false"
+      data-path=".to_replace"
+      :errors="errors"
     ></ListWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/SelectColumnStepForm.vue
+++ b/src/components/stepforms/SelectColumnStepForm.vue
@@ -8,8 +8,10 @@
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.columns[editedStep.columns.length-1] })"
       placeholder="Add columns"
+      data-path=".columns"
+      :errors="errors"
     ></MultiselectWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/SortStepForm.vue
+++ b/src/components/stepforms/SortStepForm.vue
@@ -9,9 +9,11 @@
       :defaultItem="defaultSortColumn"
       :widget="widgetSortColumn"
       :automatic-new-field="false"
+      data-path=".columns"
+      :errors="errors"
     ></ListWidget>
 
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -7,12 +7,16 @@
       type="number"
       name="Get top..."
       placeholder="Enter a number of rows"
+      data-path=".limit"
+      :errors="errors"
     ></InputTextWidget>
     <ColumnPicker
       id="rankOnInput"
       v-model="editedStep.rank_on"
       name="Sort column..."
       placeholder="Enter a column"
+      data-path=".rank_on"
+      :errors="errors"
     ></ColumnPicker>
     <AutocompleteWidget
       id="sortOrderInput"
@@ -20,6 +24,8 @@
       name="Sort order:"
       :options="['asc', 'desc']"
       placeholder="Select an order"
+      data-path=".sort"
+      :errors="errors"
     ></AutocompleteWidget>
     <MultiselectWidget
       id="groupbyColumnsInput"
@@ -28,8 +34,10 @@
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.groups[editedStep.groups.length-1] })"
       placeholder="Select columns"
+      data-path=".groups"
+      :errors="errors"
     ></MultiselectWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/UnpivotStepForm.vue
+++ b/src/components/stepforms/UnpivotStepForm.vue
@@ -8,6 +8,8 @@
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.keep[0] })"
       placeholder="Add columns to keep"
+      data-path=".keep"
+      :errors="errors"
     ></MultiselectWidget>
     <MultiselectWidget
       id="unpivotColumnInput"
@@ -16,21 +18,27 @@
       :options="columnNames"
       @input="setSelectedColumns({ column: editedStep.unpivot[0] })"
       placeholder="Add columns to unpivot"
+      data-path=".unpivot"
+      :errors="errors"
     ></MultiselectWidget>
     <InputTextWidget
       id="unpivotColumnNameInput"
       v-model="editedStep.unpivot_column_name"
       name="Category column name"
       placeholder="Enter a column name"
+      data-path=".unpivot_column_name"
+      :errors="errors"
     ></InputTextWidget>
     <InputTextWidget
       id="valueColumnNameInput"
       v-model="editedStep.value_column_name"
       name="Value column name"
       placeholder="Enter a column name"
+      data-path=".value_column_name"
+      :errors="errors"
     ></InputTextWidget>
     <CheckboxWidget id="dropnaCheckbox" :label="checkboxLabel" v-model="editedStep.dropna"></CheckboxWidget>
-    <step-form-buttonbar :errors="errors" :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
 

--- a/src/components/stepforms/schemas/filter.ts
+++ b/src/components/stepforms/schemas/filter.ts
@@ -1,94 +1,3 @@
-const singleValueConditionSchema = {
-  type: ['string', 'number', 'boolean', 'null'],
-  minLength: 1,
-  title: 'Value',
-  description: 'The value to compare',
-  attrs: {
-    placeholder: 'Enter a value',
-  },
-};
-
-const multipleValueConditionSchema = {
-  type: 'array',
-  minItems: 1,
-  items: {
-    type: ['string', 'number', 'boolean', 'null'],
-  },
-  title: 'Value',
-  description: 'The value(s) to compare',
-  attrs: {
-    placeholder: 'Enter a value',
-  },
-};
-
-const simpleConditionSchema = {
-  type: 'object',
-  properties: {
-    column: {
-      type: 'string',
-      minLength: 1,
-      title: 'Column name',
-      description: 'The name of the column you want to filter on.',
-      attrs: {
-        placeholder: 'Enter the column name',
-      },
-    },
-    value: {
-      oneOf: [singleValueConditionSchema, multipleValueConditionSchema],
-    },
-    operator: {
-      type: 'string',
-      enum: ['eq', 'ne', 'gt', 'ge', 'lt', 'le', 'in', 'nin'],
-      title: 'Operator',
-      description: 'The filter operator',
-      attrs: {
-        placeholder: 'Choose the filter operator',
-      },
-    },
-  },
-  required: ['column', 'value', 'operator'],
-  additionalProperties: false,
-};
-
-const complexConditionSchema = {
-  id: 'complexCondition',
-  type: 'object',
-  oneOf: [
-    {
-      properties: {
-        and: {
-          type: 'array',
-          minItems: 1,
-          title: 'And condition',
-          description: 'A condition "and" as a list of children conditions',
-          items: {
-            type: 'object',
-            anyOf: [simpleConditionSchema, { $ref: 'complexCondition' }],
-          },
-        },
-      },
-      required: ['and'],
-      additionalProperties: false,
-    },
-    {
-      properties: {
-        or: {
-          type: 'array',
-          minItems: 1,
-          title: 'Or condition',
-          description: 'A condition "or" as a list of children conditions',
-          items: {
-            type: 'object',
-            anyOf: [simpleConditionSchema, { $ref: 'complexCondition' }],
-          },
-        },
-      },
-      required: ['or'],
-      additionalProperties: false,
-    },
-  ],
-};
-
 export default {
   $schema: 'http://json-schema.org/draft-07/schema#',
   title: 'Filter schema',
@@ -100,7 +9,52 @@ export default {
     },
     condition: {
       type: 'object',
-      oneOf: [simpleConditionSchema, complexConditionSchema],
+      properties: {
+        and: {
+          type: 'array',
+          minItems: 1,
+          title: 'And condition',
+          items: { $ref: '#/definitions/simpleCondition' }
+        },
+      },
+      required: ['and'],
+      additionalProperties: false,
+    },
+  },
+  definitions: {
+    simpleCondition: {
+      type: 'object',
+      properties: {
+        column: {
+          type: 'string',
+          minLength: 1,
+          title: 'Column name',
+          description: 'The name of the column you want to filter on.',
+          attrs: {
+            placeholder: 'Enter the column name',
+          },
+        },
+        value: {
+          type: ['string', 'number', 'boolean', 'null', 'array'],
+          minLength: 1,
+          title: 'Value',
+          description: 'The value to compare',
+          attrs: {
+            placeholder: 'Enter a value',
+          },
+        },
+        operator: {
+          type: 'string',
+          enum: ['eq', 'ne', 'gt', 'ge', 'lt', 'le', 'in', 'nin'],
+          title: 'Operator',
+          description: 'The filter operator',
+          attrs: {
+            placeholder: 'Choose the filter operator',
+          },
+        },
+      },
+      required: ['column', 'value', 'operator'],
+      additionalProperties: false,
     },
   },
   required: ['name', 'condition'],

--- a/src/components/stepforms/widgets/Aggregation.vue
+++ b/src/components/stepforms/widgets/Aggregation.vue
@@ -6,6 +6,8 @@
       v-model="aggregation.column"
       name="Column:"
       placeholder="Enter a column"
+      :data-path="`${dataPath}.column`"
+      :errors="errors"
     ></AutocompleteWidget>
     <AutocompleteWidget
       id="aggregationFunctionInput"
@@ -13,6 +15,8 @@
       name="Function:"
       :options="aggregationFunctions"
       placeholder="Aggregation function"
+      :data-path="`${dataPath}.aggfunction`"
+      :errors="errors"
     ></AutocompleteWidget>
   </fieldset>
 </template>
@@ -22,6 +26,7 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { Getter } from 'vuex-class';
 import { AggFunctionStep } from '@/lib/steps';
 import AutocompleteWidget from './Autocomplete.vue';
+import { ErrorObject } from 'ajv';
 
 @Component({
   name: 'aggregation-widget',
@@ -30,8 +35,14 @@ import AutocompleteWidget from './Autocomplete.vue';
   },
 })
 export default class AggregationWidget extends Vue {
+  @Prop({ type: String, default: null })
+  dataPath!: string;
+
   @Prop({ type: Object, default: () => ({ column: '', aggfunction: 'sum', newcolumn: '' }) })
   value!: AggFunctionStep;
+
+  @Prop({ type: Array, default: () => [] })
+  errors!: ErrorObject[];
 
   @Getter columnNames!: string[];
 

--- a/src/components/stepforms/widgets/Autocomplete.vue
+++ b/src/components/stepforms/widgets/Autocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="widget-autocomplete__container">
+  <div class="widget-autocomplete__container" :class="toggleClassError">
     <label class="widget-autocomplete__label" v-if="name" :for="id">{{ name }}</label>
     <multiselect
       v-model="editedValue"
@@ -9,12 +9,14 @@
       :track-by="trackBy"
       :label="label"
     ></multiselect>
+    <div v-if="messageError" class="field__msg-error"><span class="fa fa-exclamation-circle"></span>{{ messageError }}</div>
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch, Mixins } from 'vue-property-decorator';
 import Multiselect from 'vue-multiselect';
+import FormWidget from './FormWidget.vue';
 
 @Component({
   name: 'autocomplete-widget',
@@ -22,7 +24,7 @@ import Multiselect from 'vue-multiselect';
     Multiselect,
   },
 })
-export default class AutocompleteWidget extends Vue {
+export default class AutocompleteWidget extends Mixins(FormWidget) {
   @Prop({ type: String, default: null })
   id!: string;
 

--- a/src/components/stepforms/widgets/FilterSimpleCondition.vue
+++ b/src/components/stepforms/widgets/FilterSimpleCondition.vue
@@ -7,6 +7,8 @@
         :options="columnNames"
         @input="setSelectedColumns({ column: editedValue.column })"
         placeholder="Column"
+        :data-path="`${dataPath}.column`"
+        :errors="errors"
       ></AutocompleteWidget>
     </div>
     <div class="filter-form-simple-condition-operator-input">
@@ -20,7 +22,13 @@
         :label="`label`"
       ></AutocompleteWidget>
     </div>
-    <component :is="inputWidget" v-model="editedValue.value" :placeholder="placeholder"></component>
+    <component
+      :is="inputWidget"
+      v-model="editedValue.value"
+      :placeholder="placeholder"
+      :data-path="`${dataPath}.value`"
+      :errors="errors"
+    ></component>
   </div>
 </template>
 
@@ -33,6 +41,7 @@ import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import MultiInputTextWidget from './MultiInputText.vue';
 import { FilterSimpleCondition } from '@/lib/steps';
 import { VueConstructor } from 'vue';
+import { ErrorObject } from 'ajv';
 
 type LiteralOperator =
   | 'equal'
@@ -65,6 +74,12 @@ export default class FilterSimpleConditionWidget extends Vue {
     default: () => ({ column: '', value: '', operator: 'eq' }),
   })
   value!: FilterSimpleCondition;
+
+  @Prop({ type: String, default: null })
+  dataPath!: string;
+
+  @Prop({ type: Array, default: () => [] })
+  errors!: ErrorObject[];
 
   @Getter columnNames!: string[];
 
@@ -121,7 +136,6 @@ export default class FilterSimpleConditionWidget extends Vue {
   margin-right: 10px;
   width: 33%;
 }
-
 .filter-form-simple-condition-operator-input {
   margin-right: 10px;
   width: 33%;
@@ -137,6 +151,12 @@ export default class FilterSimpleConditionWidget extends Vue {
   margin-bottom: 0px;
   margin-right: 10px;
   width: 33%;
+}
+</style>
+
+<style lang="scss">
+.filter-form-simple-condition__container .multiselect {
+  width: 100%;
 }
 </style>
 

--- a/src/components/stepforms/widgets/FormWidget.vue
+++ b/src/components/stepforms/widgets/FormWidget.vue
@@ -1,0 +1,52 @@
+<script lang="ts">
+
+import { Component, Vue, Prop } from 'vue-property-decorator';
+import { ErrorObject } from 'ajv';
+
+@Component({
+  name: 'form-widget',
+})
+export default class FormWidget extends Vue {
+  @Prop({ type: String })
+  dataPath!: string;
+
+  @Prop({ type: Array, default: () => [] })
+  errors!: ErrorObject[];
+
+  get error() {
+    if(this.errors === null || this.errors === undefined) {
+      return;
+    } else {
+      return this.errors.find(d => d.dataPath == this.dataPath);
+    }
+  }
+
+  get messageError() {
+    if(this.error !== undefined) {
+      return this.error.message;
+    }
+    return null;
+  }
+
+  get toggleClassError() {
+    return { 'field--error': this.messageError !== undefined && this.messageError !== null  };
+  }
+
+}
+
+</script>
+
+<style lang="scss">
+.field--error .widget-input-text,
+.field--error .multiselect__tags {
+  box-shadow: 0 0 0 1px #d40000 inset;
+}
+.field__msg-error {
+  color: #d40000;
+  font-size: 12px;
+  margin-top: 5px;
+}
+.field__msg-error .fa-exclamation-circle {
+  margin-right: 5px;
+}
+</style>

--- a/src/components/stepforms/widgets/InputText.vue
+++ b/src/components/stepforms/widgets/InputText.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="widget-input-text__container">
+  <div class="widget-input-text__container" :class="toggleClassError">
     <label v-if="name" :for="id">{{name}}</label>
     <input
       :id="id"
@@ -11,15 +11,18 @@
       @focus="focus()"
       @input="updateValue($event.target.value)"
     />
+    <div v-if="messageError" class="field__msg-error"><span class="fa fa-exclamation-circle"></span>{{ messageError }}</div>
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue, Mixins } from 'vue-property-decorator';
+import FormWidget from './FormWidget.vue';
+
 @Component({
   name: 'input-text-widget',
 })
-export default class InputTextWidget extends Vue {
+export default class InputTextWidget extends Mixins(FormWidget) {
   @Prop({ type: String, default: null })
   id!: string;
 

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -1,15 +1,22 @@
 <template>
-  <div class="widget-list__container">
+  <div class="widget-list__container" :class="toggleClassError">
     <label :for="id">{{name}}</label>
     <div class="widget-list__body">
       <div class="widget-list__child" v-for="(child, index) in children" :key="index">
         <div class="widget-list__component">
-          <component :is="widget" :value="child.value" @input="updateChildValue($event, index)"></component>
+          <component
+            :is="widget"
+            :value="child.value"
+            @input="updateChildValue($event, index)"
+            :data-path="`${dataPath}[${index}]`"
+            :errors="errors">
+          </component>
         </div>
         <div class="widget-list__icon" v-if="child.isRemovable" @click="removeChild(index)">
           <i class="far fa-trash-alt"></i>
         </div>
       </div>
+      <div v-if="messageError" class="field__msg-error"><span class="fa fa-exclamation-circle"></span>{{ messageError }}</div>
       <button v-if="!automaticNewField" class="widget-list__add-fieldset" @click="addFieldSet">
         <i class="fas fa-plus-circle"></i>
         {{ addFieldName }}
@@ -19,9 +26,11 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue, Mixins } from 'vue-property-decorator';
 import { VueConstructor } from 'vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+import FormWidget from './FormWidget.vue';
+import { ErrorObject } from 'ajv';
 
 type Field = {
   name: string;
@@ -34,7 +43,7 @@ type RepeatableField = Field[];
 @Component({
   name: 'list-widget',
 })
-export default class ListWidget extends Vue {
+export default class ListWidget extends Mixins(FormWidget) {
   @Prop({ type: String, default: '' })
   addFieldName!: string;
 
@@ -58,6 +67,12 @@ export default class ListWidget extends Vue {
 
   @Prop({ default: null })
   defaultItem!: string | RepeatableField;
+
+  @Prop({ type: Array, default: () => [] })
+  errors!: ErrorObject[];
+
+  @Prop({ default: null })
+  dataPath!: string;
 
   get children() {
     const valueCopy = [...this.value];
@@ -162,9 +177,13 @@ export default class ListWidget extends Vue {
   align-items: center;
   flex-direction: row;
   margin-bottom: 8px;
+  flex-wrap: wrap;
 }
 .widget-list__container .widget-autocomplete__label {
   margin-bottom: 0px;
   width: 40%;
+}
+.widget-list__component .multiselect {
+  width: 60%;
 }
 </style>

--- a/src/components/stepforms/widgets/Multiselect.vue
+++ b/src/components/stepforms/widgets/Multiselect.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="widget-multiselect__container">
+  <div class="widget-multiselect__container" :class="toggleClassError">
     <label class="widget-multiselect__label" :for="id">{{ name }}</label>
     <multiselect
       v-model="editedValue"
@@ -9,12 +9,14 @@
       :taggable="true"
       :close-on-select="false"
     ></multiselect>
+    <div v-if="messageError" class="field__msg-error"><span class="fa fa-exclamation-circle"></span>{{ messageError }}</div>
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch, Mixins } from 'vue-property-decorator';
 import Multiselect from 'vue-multiselect';
+import FormWidget from './FormWidget.vue';
 
 @Component({
   name: 'multiselect-widget',
@@ -22,7 +24,7 @@ import Multiselect from 'vue-multiselect';
     Multiselect,
   },
 })
-export default class MultiselectWidget extends Vue {
+export default class MultiselectWidget extends Mixins(FormWidget) {
   @Prop({ type: String, default: null })
   id!: string;
 

--- a/src/components/stepforms/widgets/Replace.vue
+++ b/src/components/stepforms/widgets/Replace.vue
@@ -1,13 +1,26 @@
 <template>
   <div class="widget-to-replace__container">
-    <InputTextWidget id="valueToReplace" v-model="toReplace[0]" placeholder="Value to replace"></InputTextWidget>
-    <InputTextWidget id="newValue" v-model="toReplace[1]" placeholder="New value"></InputTextWidget>
+    <InputTextWidget
+      id="valueToReplace"
+      v-model="toReplace[0]"
+      placeholder="Value to replace"
+      :data-path="`${dataPath}[0]`"
+      :errors="errors"
+    ></InputTextWidget>
+    <InputTextWidget
+      id="newValue"
+      v-model="toReplace[1]"
+      placeholder="New value"
+      :data-path="`${dataPath}[1]`"
+      :errors="errors"
+    ></InputTextWidget>
   </div>
 </template>
 <script lang="ts">
 import _ from 'lodash';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import InputTextWidget from './InputText.vue';
+import { ErrorObject } from 'ajv';
 
 @Component({
   name: 'replace-widget',
@@ -21,6 +34,12 @@ export default class ReplaceWidget extends Vue {
     default: () => ['', ''],
   })
   value!: any[];
+
+  @Prop({ type: String, default: null })
+  dataPath!: string;
+
+  @Prop({ type: Array, default: () => [] })
+  errors!: ErrorObject[];
 
   toReplace: any[] = [...this.value];
 

--- a/src/components/stepforms/widgets/SortColumn.vue
+++ b/src/components/stepforms/widgets/SortColumn.vue
@@ -7,6 +7,8 @@
       name="Column"
       placeholder="Enter a column"
       @input="setSelectedColumns({ column: sort.column })"
+      :data-path="`${dataPath}[0]`"
+      :errors="errors"
     ></AutocompleteWidget>
     <AutocompleteWidget
       id="sortOrderInput"
@@ -14,6 +16,8 @@
       name="Order"
       :options="['asc', 'desc']"
       placeholder="Order by"
+      :data-path="`${dataPath}[1]`"
+      :errors="errors"
     ></AutocompleteWidget>
   </fieldset>
 </template>
@@ -24,6 +28,7 @@ import { Getter, Mutation } from 'vuex-class';
 import { MutationCallbacks } from '@/store/mutations';
 import AutocompleteWidget from './Autocomplete.vue';
 import { SortColumnType } from '@/lib/steps';
+import { ErrorObject } from 'ajv';
 
 @Component({
   name: 'sort-column-widget',
@@ -40,6 +45,12 @@ export default class SortColumnWidget extends Vue {
     }),
   })
   value!: SortColumnType;
+
+  @Prop({ type: String, default: null })
+  dataPath!: string;
+
+  @Prop({ type: Array, default: () => [] })
+  errors!: ErrorObject[];
 
   @Getter columnNames!: string[];
 

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -72,7 +72,7 @@ describe('Filter Step Form', () => {
       keyword: err.keyword,
       dataPath: err.dataPath,
     }));
-    expect(errors).toContainEqual({ dataPath: '.condition', keyword: 'oneOf' });
+    expect(errors).toContainEqual({ dataPath: '.condition.and', keyword: 'minItems' });
   });
 
   it('should validate and emit "formSaved" when submitting a valid condition', () => {

--- a/tests/unit/form-widget.spec.ts
+++ b/tests/unit/form-widget.spec.ts
@@ -1,0 +1,60 @@
+import { shallowMount } from '@vue/test-utils';
+import FormWidget from '@/components/stepforms/widgets/FormWidget.vue';
+import { Component, Mixins } from 'vue-property-decorator';
+
+/* Fake widget use to manage the mixins render issue */
+@Component({
+  name: 'fake-widget',
+})
+export default class FakeWidget extends Mixins(FormWidget) {
+  render(){}
+}
+
+describe('Form widget', () => {
+  it('should return correctly messageError', () => {
+    const wrapper = shallowMount(FakeWidget, {
+      propsData: {
+        dataPath: '.column',
+        errors: [{
+          dataPath: '.column',
+          message: 'test error'
+        }]
+      }
+    });
+    expect((wrapper.vm as any).messageError).toEqual('test error');
+  });
+
+  it('should return correctly messageError with others messageError', () => {
+    const wrapper = shallowMount(FakeWidget, {
+      propsData: {
+        dataPath: '.condition',
+        errors: [{
+          dataPath: '.column',
+          message: 'test error'
+        },
+        {
+          dataPath: '.condition',
+          message: 'Message error condition is missing'
+        },
+        {
+          dataPath: '.column',
+          message: 'test error'
+        }]
+      }
+    });
+    expect((wrapper.vm as any).messageError).toEqual('Message error condition is missing');
+  });
+
+  it('should return classname "field--error: true" in case of error', () => {
+    const wrapper = shallowMount(FakeWidget, {
+      propsData: {
+        dataPath: '.condition',
+        errors: [{
+          dataPath: '.condition',
+          message: 'test error'
+        }]
+      }
+    });
+    expect((wrapper.vm as any).toggleClassError).toEqual({"field--error": true});
+  });
+});


### PR DESCRIPTION
To avoid many modifications into each form step we use the mixins : `formWidget`. This mixins compute, the field message error and classError by matching right error with `dataPath` props pass by its step form parent component.

For `filterStepForm` we needed to change his schema to remove in and and conditions operator (for the moment) otherwise there was too many errors to display.

![image](https://user-images.githubusercontent.com/4438175/63875359-9c52f980-c9c3-11e9-8d7e-95a412f865eb.png)

![image](https://user-images.githubusercontent.com/4438175/63875397-a96fe880-c9c3-11e9-8df9-c883345a75ac.png)

![image](https://user-images.githubusercontent.com/4438175/64351949-7e0c7f80-cffb-11e9-88ea-0c0094012b05.png)

closes #181 
