### PR TITLE
FIX :: allow scroll to pipeline steps  

### DIFF
--- a/src/styles/Steps.scss
+++ b/src/styles/Steps.scss
@@ -16,6 +16,7 @@
   align-items: center;
   height: 70px;
   width: 100%;
+  flex-shrink: 0;
 }
 
 .query-pipeline-step__container--last-active,


### PR DESCRIPTION
It was just a flex issue, the height of each steps was resized depends to screen size height. 

Quick win by using the `flex-shrink: 0;` proprety on step container.

closes https://github.com/ToucanToco/vue-query-builder/issues/285

Now we get a scrollbar : 
![image](https://user-images.githubusercontent.com/4438175/64242556-0ad51180-cf06-11e9-8b37-eb6d05f24b0e.png)
