### PR TITLE
Do not create conflicting interactions between form fields

### DIFF
--- a/src/components/stepforms/PercentageStepForm.vue
+++ b/src/components/stepforms/PercentageStepForm.vue
@@ -12,7 +12,6 @@
       v-model="editedStep.group"
       name="(Optional) Group by..."
       :options="columnNames"
-      @input="setSelectedColumns({ column: editedStep.group[editedStep.group.length-1] })"
       placeholder="Add columns"
     ></MultiselectWidget>
     <InputTextWidget


### PR DESCRIPTION
When selecting a column in the "group by" field it changed the
focus of column, and consequently changed the value of the "value
column" field (`ColumnPicker` component)
To avoid that we just removed the interaction on the "group by"
field.
We will have to wait to scope interactions better in the futur to
get this interaction back