### PR TITLE
Fix :: pagination total count

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -98,7 +98,6 @@ async function setupInitialData(store, domain = null) {
       store.commit('setDataset', { dataset: response.data });
     }
   }
-  store.commit('setDataset', { dataset: response.data });
 }
 
 async function buildVueApp() {

--- a/playground/app.js
+++ b/playground/app.js
@@ -20,15 +20,7 @@ class MongoService {
   async executePipeline(pipeline, limit, offset = 0) {
     const { domain, pipeline: subpipeline } = filterOutDomain(pipeline);
     const query = mongo36translator.translate(subpipeline);
-    // first offset
-    if (offset) {
-      query.push({ $skip: offset });
-    }
-    // then limit
-    if (limit) {
-      query.push({ $limit: limit });
-    }
-    const { isResponseOk, responseContent } = await this.executeQuery(query, domain);
+    const { isResponseOk, responseContent } = await this.executeQuery(query, domain, limit, offset);
 
     if (isResponseOk) {
       const [{ count, data: rset }] = responseContent;
@@ -49,12 +41,14 @@ class MongoService {
     }
   }
 
-  async executeQuery(query, collection) {
+  async executeQuery(query, collection, limit, skip) {
     const response = await fetch('/query', {
       method: 'POST',
       body: JSON.stringify({
         query,
         collection,
+        limit,
+        skip,
       }),
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
In order to have a logical count when returning data after changes in the pipeline, we have to `facetize` our query in order to keep count of our query and then skip/limit it in order to return only a part of the data. 