### PR TITLE
Fix :: change offset computing method to get the good align right position

### DIFF
--- a/src/components/domutil.ts
+++ b/src/components/domutil.ts
@@ -82,10 +82,10 @@ function completeClientRect(customRect: Partial<ClientRect> = {}): ClientRect {
  */
 function completeOffset(customOffset: Partial<ElementOffset> = {}): ElementOffset {
   const defaultOffset = {
-    offsetWidth: 0,
-    offsetHeight: 0,
+    offsetWidth: customOffset.offsetWidth || 0,
+    offsetHeight: customOffset.offsetHeight || 0,
   };
-  return { ...defaultOffset, ...customOffset };
+  return defaultOffset;
 }
 
 /**


### PR DESCRIPTION
closes this issue : https://github.com/ToucanToco/vue-query-builder/issues/303

now when the popover is out of screen :
![image](https://user-images.githubusercontent.com/4438175/65049977-f4e43980-d966-11e9-89ad-11a419aacd53.png)
