### PR TITLE
Simplify replace step

### DIFF
--- a/doc/steps.md
+++ b/doc/steps.md
@@ -608,7 +608,7 @@ Rename a column.,
 
 ### `replace` step
 
-Replace one or several values in a column, and write resulting column inplace or in a new column.
+Replace one or several values in a column.
 
 A replace step has the following strucure:
 
@@ -616,7 +616,6 @@ A replace step has the following strucure:
 {
    name: 'replace',
    search_column: "column_1",
-   new_column: "column_2", // if empty, replace values directly in `search_column` by default
    to_replace: [
      ['foo', 'bar'], // The first value is the one to be replace, the second is the new value
      [42, 0]
@@ -626,14 +625,14 @@ A replace step has the following strucure:
 }
 ```
 
-### Example 1: Replace a single value inplace
+### Example
 
 **Input dataset:**
 
 | COMPANY   | COUNTRY |
 | --------- | ------- |
 | Company 1 | Fr      |
-| Company 2 | USA     |
+| Company 2 | UK      |
 
 **Step configuration:**
 
@@ -643,46 +642,17 @@ A replace step has the following strucure:
    search_column: "COUNTRY",
    to_replace: [
      ['Fr', 'France']
+     ['UK', 'United Kingdom']
    ]
 }
 ```
 
 **Output dataset:**
 
-| COMPANY   | COUNTRY |
-| --------- | ------- |
-| Company 1 | France  |
-| Company 2 | USA     |
-
-### Example 2: Replace several values at once in a new column
-
-**Input dataset:**
-
-| COMPANY   | COUNTRY |
-| --------- | ------- |
-| Company 1 | France  |
-| Company 2 | USA     |
-
-**Step configuration:**
-
-```javascript
-{
-   name: 'replace',
-   search_column: "COUNTRY",
-   new_column: "REGION"
-   to_replace: [
-     ['France', 'Europe']
-     ['USA': 'North America']
-   ]
-}
-```
-
-**Output dataset:**
-
-| COMPANY   | COUNTRY | REGION        |
-| --------- | ------- | ------------- |
-| Company 1 | France  | Europe        |
-| Company 2 | USA     | North America |
+| COMPANY   | COUNTRY        |
+| --------- | -------------- |
+| Company 1 | France         |
+| Company 2 | United Kingdom |
 
 ### `select` step
 

--- a/src/components/stepforms/ReplaceStepForm.vue
+++ b/src/components/stepforms/ReplaceStepForm.vue
@@ -9,14 +9,6 @@
       data-path=".search_column"
       :errors="errors"
     ></ColumnPicker>
-    <InputTextWidget
-      id="newColumnInput"
-      v-model="editedStep.new_column"
-      name="(Optional) Write output in..."
-      placeholder="Enter a new column name"
-      data-path=".new_column"
-      :errors="errors"
-    ></InputTextWidget>
     <ListWidget
       addFieldName="Add a value to replace"
       id="toReplace"
@@ -37,7 +29,6 @@ import { VQBModule } from '@/store';
 import { Prop } from 'vue-property-decorator';
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import ListWidget from '@/components/stepforms/widgets/List.vue';
 import ReplaceWidget from '@/components/stepforms/widgets/Replace.vue';
 import BaseStepForm from './StepForm.vue';
@@ -50,7 +41,6 @@ import { castFromString } from '@/lib/helpers';
   name: 'replace-step-form',
   components: {
     ColumnPicker,
-    InputTextWidget,
     ListWidget,
   },
 })

--- a/src/components/stepforms/schemas/index.ts
+++ b/src/components/stepforms/schemas/index.ts
@@ -10,7 +10,7 @@ import formulaSchema from './formula';
 import percentageBuildSchema from './percentage';
 import pivotSchema from './pivot';
 import renameBuildSchema from './rename';
-import replaceBuildSchema from './replace';
+import replaceSchema from './replace';
 import selectSchema from './select';
 import topBuildSchema from './top';
 import unpivotSchema from './unpivot';
@@ -31,7 +31,7 @@ const factories: { [stepname: string]: buildSchemaType } = {
   percentage: percentageBuildSchema,
   pivot: pivotSchema,
   rename: renameBuildSchema,
-  replace: replaceBuildSchema,
+  replace: replaceSchema,
   select: selectSchema,
   top: topBuildSchema,
   unpivot: unpivotSchema,

--- a/src/components/stepforms/schemas/replace.ts
+++ b/src/components/stepforms/schemas/replace.ts
@@ -1,6 +1,4 @@
-import { StepFormType, addNotInColumnNamesConstraint } from './utils';
-
-const schema = {
+export default {
   $schema: 'http://json-schema.org/draft-07/schema#',
   title: 'Replace step',
   type: 'object',
@@ -14,18 +12,6 @@ const schema = {
       items: {
         type: 'string',
         minLength: 1,
-      },
-      title: 'Search',
-      description: 'Columns in which to search values to replace',
-      attrs: {
-        placeholder: 'Enter a column',
-      },
-    },
-    new_column: {
-      type: 'string',
-      items: {
-        type: 'string',
-        minLength: 0,
       },
       title: 'Search',
       description: 'Columns in which to search values to replace',
@@ -52,7 +38,3 @@ const schema = {
   required: ['name', 'search_column', 'to_replace'],
   additionalProperties: false,
 };
-
-export default function buildSchema(form: StepFormType) {
-  return addNotInColumnNamesConstraint(schema, 'new_column', form.columnNames);
-}

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -126,7 +126,6 @@ export type RenameStep = {
 export type ReplaceStep = {
   name: 'replace';
   search_column: string;
-  new_column?: string;
   to_replace: any[][];
 };
 

--- a/src/lib/translators/mongo.ts
+++ b/src/lib/translators/mongo.ts
@@ -293,7 +293,7 @@ function transformReplace(step: Readonly<ReplaceStep>): MongoStep {
   }));
   return {
     $addFields: {
-      [step.new_column || step.search_column]: {
+      [step.search_column]: {
         $switch: { branches: branches, default: $$(step.search_column) },
       },
     },

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -285,7 +285,6 @@ describe('Labeller', () => {
     const step: S.ReplaceStep = {
       name: 'replace',
       search_column: 'column1',
-      new_column: 'column2',
       to_replace: [[4, 2]],
     };
     expect(hrl(step)).toEqual('Replace 4 with 2 in column "column1"');
@@ -295,7 +294,6 @@ describe('Labeller', () => {
     const step: S.ReplaceStep = {
       name: 'replace',
       search_column: 'column1',
-      new_column: 'column2',
       to_replace: [[4, 2], [5, 3]],
     };
     expect(hrl(step)).toEqual('Replace values in column "column1"');

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -620,36 +620,11 @@ describe('Pipeline to mongo translator', () => {
     ]);
   });
 
-  it('can generate a replace step with a single value to replace inplace', () => {
+  it('can generate a replace step', () => {
     const pipeline: Pipeline = [
       {
         name: 'replace',
         search_column: 'column_1',
-        to_replace: [['foo', 'bar']],
-      },
-    ];
-    const querySteps = mongo36translator.translate(pipeline);
-    expect(querySteps).toEqual([
-      {
-        $addFields: {
-          column_1: {
-            $switch: {
-              branches: [{ case: { $eq: ['$column_1', 'foo'] }, then: 'bar' }],
-              default: '$column_1',
-            },
-          },
-        },
-      },
-      { $project: { _id: 0 } },
-    ]);
-  });
-
-  it('can generate a replace step with a several values to replace in a new column', () => {
-    const pipeline: Pipeline = [
-      {
-        name: 'replace',
-        search_column: 'column_1',
-        new_column: 'column_2',
         to_replace: [['foo', 'bar'], ['old', 'new']],
       },
     ];
@@ -657,7 +632,7 @@ describe('Pipeline to mongo translator', () => {
     expect(querySteps).toEqual([
       {
         $addFields: {
-          column_2: {
+          column_1: {
             $switch: {
               branches: [
                 { case: { $eq: ['$column_1', 'foo'] }, then: 'bar' },

--- a/tests/unit/replace-step-form.spec.ts
+++ b/tests/unit/replace-step-form.spec.ts
@@ -7,11 +7,6 @@ import { setupMockStore } from './utils';
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
-interface ValidationError {
-  dataPath: string;
-  keyword: string;
-}
-
 describe('Replace Step Form', () => {
   let emptyStore: Store<any>;
   beforeEach(() => {
@@ -24,13 +19,11 @@ describe('Replace Step Form', () => {
     expect(wrapper.vm.$data.stepname).toEqual('replace');
   });
 
-  it('should have exactly 3 input components', () => {
+  it('should have exactly 2 input components', () => {
     const wrapper = shallowMount(ReplaceStepForm, { store: emptyStore, localVue, sync: false });
     const columnPickerWrappers = wrapper.findAll('columnpicker-stub');
-    const inputTextWrappers = wrapper.findAll('inputtextwidget-stub');
     const widgetListWrappers = wrapper.findAll('listwidget-stub');
     expect(columnPickerWrappers.length).toEqual(1);
-    expect(inputTextWrappers.length).toEqual(1);
     expect(widgetListWrappers.length).toEqual(1);
   });
 
@@ -52,25 +45,6 @@ describe('Replace Step Form', () => {
     expect(wrapper.find('columnpicker-stub').attributes().value).toEqual('test');
   });
 
-  it('should pass down "new_column" to InputTextWidget', () => {
-    const wrapper = shallowMount(ReplaceStepForm, {
-      store: emptyStore,
-      localVue,
-      sync: false,
-      data: () => {
-        return {
-          editedStep: {
-            name: 'replace',
-            search_column: 'test',
-            new_column: 'newTest',
-            to_replace: [['foo', 'bar']],
-          },
-        };
-      },
-    });
-    expect(wrapper.find('inputtextwidget-stub').props().value).toEqual('newTest');
-  });
-
   it('should pass down "to_replace" to ListWidget', () => {
     const wrapper = shallowMount(ReplaceStepForm, {
       store: emptyStore,
@@ -81,7 +55,6 @@ describe('Replace Step Form', () => {
           editedStep: {
             name: 'replace',
             search_column: 'test',
-            new_column: 'newTest',
             to_replace: [['foo', 'bar']],
           },
         };
@@ -100,45 +73,12 @@ describe('Replace Step Form', () => {
           editedStep: {
             name: 'replace',
             search_column: 'test',
-            new_column: 'newTest',
             to_replace: [],
           },
         };
       },
     });
     expect(wrapper.find('listwidget-stub').props().value).toEqual([[]]);
-  });
-
-  it('should report errors when the data is not valid', async () => {
-    const store = setupMockStore({
-      dataset: {
-        headers: [{ name: 'foo', type: 'string' }, { name: 'bar', type: 'string' }],
-        data: [],
-      },
-    });
-    const wrapper = mount(ReplaceStepForm, {
-      store,
-      localVue,
-      sync: false,
-      data: () => {
-        return {
-          editedStep: {
-            name: 'replace',
-            search_column: 'foo',
-            to_replace: [['', '']],
-            new_column: 'bar',
-          },
-        };
-      },
-    });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    const errors = wrapper.vm.$data.errors
-      .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
-      .sort((err1: ValidationError, err2: ValidationError) =>
-        err1.dataPath.localeCompare(err2.dataPath),
-      );
-    expect(errors).toEqual([{ keyword: 'columnNameAlreadyUsed', dataPath: '.new_column' }]);
   });
 
   it('should validate and emit "formSaved" when submitted data is valid', async () => {


### PR DESCRIPTION
Remove the optional new_column parameter
If needing to replace values in a new column, the user can first
duplicate the column, and then apply the replacement in the new
column.

Closes https://github.com/ToucanToco/vue-query-builder/issues/296