### PR TITLE
Simplify duplicate step

### DIFF
--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -2,7 +2,7 @@
   <popover :active="isActive" :align="alignLeft" bottom>
     <div class="action-menu__body">
       <div class="action-menu__section">
-        <div class="action-menu__option" @click="createStep('duplicate')">Duplicate column</div>
+        <div class="action-menu__option" @click="createDuplicateColumnStep">Duplicate column</div>
         <div class="action-menu__option" @click="createStep('rename')">Rename column</div>
         <div class="action-menu__option" @click="createDeleteColumnStep">Delete column</div>
         <div class="action-menu__option" @click="createStep('fillna')">Fill null values</div>
@@ -20,6 +20,7 @@ import { POPOVER_ALIGN } from '@/components/constants';
 import Popover from './Popover.vue';
 import { Pipeline, PipelineStep, PipelineStepName } from '@/lib/steps';
 import { MutationCallbacks } from '@/store/mutations';
+import { newColumnName } from '@/lib/helpers';
 
 @Component({
   name: 'action-menu',
@@ -44,6 +45,7 @@ export default class ActionMenu extends Vue {
 
   @VQBModule.Getter computedActiveStepIndex!: number;
   @VQBModule.Getter isEditingStep!: boolean;
+  @VQBModule.Getter columnNames!: string[];
 
   @VQBModule.Mutation selectStep!: MutationCallbacks['selectStep'];
   @VQBModule.Mutation setPipeline!: MutationCallbacks['setPipeline'];
@@ -70,7 +72,7 @@ export default class ActionMenu extends Vue {
   createDeleteColumnStep() {
     const newPipeline: Pipeline = [...this.pipeline];
     const index = this.computedActiveStepIndex + 1;
-    const deletecolumnStep: PipelineStep = { name: 'delete', columns: [this.columnName] };
+    const deleteColumnStep: PipelineStep = { name: 'delete', columns: [this.columnName] };
     /**
      * If a step edition form is already open, close it so that the left panel displays
      * the pipeline with the new delete step inserted
@@ -78,7 +80,28 @@ export default class ActionMenu extends Vue {
     if (this.isEditingStep) {
       this.closeStepForm();
     }
-    newPipeline.splice(index, 0, deletecolumnStep);
+    newPipeline.splice(index, 0, deleteColumnStep);
+    this.setPipeline({ pipeline: newPipeline });
+    this.selectStep({ index });
+    this.close();
+  }
+
+  createDuplicateColumnStep() {
+    const newPipeline: Pipeline = [...this.pipeline];
+    const index = this.computedActiveStepIndex + 1;
+    const duplicateColumnStep: PipelineStep = {
+      name: 'duplicate',
+      column: this.columnName,
+      new_column_name: newColumnName(`${this.columnName}_copy`, this.columnNames),
+    };
+    /**
+     * If a step edition form is already open, close it so that the left panel displays
+     * the pipeline with the new delete step inserted
+     */
+    if (this.isEditingStep) {
+      this.closeStepForm();
+    }
+    newPipeline.splice(index, 0, duplicateColumnStep);
     this.setPipeline({ pipeline: newPipeline });
     this.selectStep({ index });
     this.close();

--- a/src/components/stepforms/DuplicateColumnStepForm.vue
+++ b/src/components/stepforms/DuplicateColumnStepForm.vue
@@ -9,14 +9,6 @@
       data-path=".column"
       :errors="errors"
     ></ColumnPicker>
-    <InputTextWidget
-      id="newColumnNameInput"
-      v-model="editedStep.new_column_name"
-      name="New column name:"
-      placeholder="Enter a column name"
-      data-path=".new_column_name"
-      :errors="errors"
-    ></InputTextWidget>
     <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
 </template>
@@ -25,16 +17,15 @@
 import { Prop } from 'vue-property-decorator';
 import { StepFormComponent } from '@/components/formlib';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
-import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import BaseStepForm from './StepForm.vue';
 import { DuplicateColumnStep } from '@/lib/steps';
+import { newColumnName } from '@/lib/helpers';
 
 @StepFormComponent({
   vqbstep: 'duplicate',
   name: 'duplicate-step-form',
   components: {
     ColumnPicker,
-    InputTextWidget,
   },
 })
 export default class DuplicateColumnForm extends BaseStepForm<DuplicateColumnStep> {
@@ -52,6 +43,14 @@ export default class DuplicateColumnForm extends BaseStepForm<DuplicateColumnSte
       throw new Error('should not try to set null on duplicate "column" field');
     }
     this.editedStep.column = colname;
+  }
+
+  submit() {
+    this.editedStep.new_column_name = newColumnName(
+      `${this.editedStep.column}_copy`,
+      this.columnNames,
+    );
+    this.$$super.submit();
   }
 }
 </script>

--- a/src/components/stepforms/schemas/duplicate.ts
+++ b/src/components/stepforms/schemas/duplicate.ts
@@ -1,6 +1,4 @@
-import { StepFormType, addNotInColumnNamesConstraint } from './utils';
-
-const schema = {
+export default {
   $schema: 'http://json-schema.org/draft-07/schema#',
   title: 'Duplicate column step',
   type: 'object',
@@ -31,7 +29,3 @@ const schema = {
   required: ['name', 'column', 'new_column_name'],
   additionalProperties: false,
 };
-
-export default function buildSchema(form: StepFormType) {
-  return addNotInColumnNamesConstraint(schema, 'new_column_name', form.columnNames);
-}

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -27,3 +27,21 @@ export function castFromString(value: string, type: DataSetColumnType) {
   }
   return value;
 }
+
+/**
+ * Takes a proposed new column name and returns a valid name that does not erase
+ * an existing column name. So if the proposed new name already exist in
+ * existing names, it appends an integer that increments until the new name
+ * becomes unique
+ *
+ * @param newName the proposed new column name
+ * @param existingNames the existing columns names
+ */
+export function newColumnName(newName: string, existingNames: string[]): string {
+  let i = 1;
+  let validNewName = newName;
+  while (existingNames.includes(validNewName)) {
+    validNewName = `${newName}${i++}`;
+  }
+  return validNewName;
+}

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -114,7 +114,7 @@ class StepLabeller implements StepMatcher<string> {
   }
 
   duplicate(step: Readonly<S.DuplicateColumnStep>) {
-    return `Duplicate "${step.column}" in "${step.new_column_name}"`;
+    return `Duplicate "${step.column}"`;
   }
 
   delete(step: Readonly<S.DeleteStep>) {

--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -36,17 +36,21 @@ describe('Action Menu', () => {
   });
 
   describe('when clicking on "Duplicate column"', () => {
-    it('should emit an "actionClicked" event with proper options', () => {
+    it('should add a valide duplicate step in the pipeline', async () => {
+      const store: Store<any> = setupMockStore();
       const wrapper = shallowMount(ActionMenu, {
+        store,
+        localVue,
         propsData: {
-          columnName: 'dreamfall',
+          columnName: 'columnA',
         },
       });
       const actionsWrapper = wrapper.findAll('.action-menu__option');
       actionsWrapper.at(0).trigger('click');
-
-      expect(wrapper.emitted().actionClicked.length).toBeGreaterThan(0);
-      expect(wrapper.emitted().actionClicked[0]).toEqual(['duplicate']);
+      await localVue.nextTick();
+      expect(store.state.vqb.pipeline).toEqual([
+        { name: 'duplicate', column: 'columnA', new_column_name: 'columnA_copy' },
+      ]);
     });
 
     it('should emit a close event', () => {
@@ -56,6 +60,14 @@ describe('Action Menu', () => {
       actionsWrapper.at(0).trigger('click');
 
       expect(wrapper.emitted().closed).toBeTruthy();
+    });
+
+    it('should close any open step form to show the addition of the duplicate step in the pipeline', () => {
+      const store = setupMockStore({ currentStepFormName: 'fillna' });
+      const wrapper = shallowMount(ActionMenu, { store, localVue });
+      const actionsWrapper = wrapper.findAll('.action-menu__option');
+      actionsWrapper.at(0).trigger('click');
+      expect(store.getters[VQBnamespace('isEditingStep')]).toBeFalsy();
     });
   });
 

--- a/tests/unit/duplicate-column-step-form.spec.ts
+++ b/tests/unit/duplicate-column-step-form.spec.ts
@@ -24,52 +24,10 @@ describe('Duplicate Column Step Form', () => {
     expect(wrapper.exists()).toBeTruthy();
   });
 
-  it('should have exactly 2 input components', () => {
+  it('should have exactly 1 input components', () => {
     const wrapper = shallowMount(DuplicateColumnStepForm, { store: emptyStore, localVue });
 
     expect(wrapper.findAll('columnpicker-stub').length).toEqual(1);
-    expect(wrapper.findAll('inputtextwidget-stub').length).toEqual(1);
-  });
-
-  describe('Errors', () => {
-    it('should report errors when submitted data is not valid', () => {
-      const wrapper = mount(DuplicateColumnStepForm, {
-        store: emptyStore,
-        localVue,
-        propsData: {
-          initialStepValue: { name: 'duplicate', column: '', new_column_name: '' },
-        },
-      });
-      wrapper.find('.widget-form-action__button--validate').trigger('click');
-      const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-        keyword: err.keyword,
-        dataPath: err.dataPath,
-      }));
-      expect(errors).toEqual([
-        { keyword: 'minLength', dataPath: '.column' },
-        { keyword: 'minLength', dataPath: '.new_column_name' },
-      ]);
-    });
-  });
-
-  it('should report errors when new_column_name is an already existing column name', async () => {
-    const store = setupMockStore({
-      dataset: {
-        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-        data: [],
-      },
-    });
-    const wrapper = mount(DuplicateColumnStepForm, { store, localVue });
-    wrapper.setData({
-      editedStep: { name: 'duplicate', column: 'foo', new_column_name: 'columnA' },
-    });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-      keyword: err.keyword,
-      dataPath: err.dataPath,
-    }));
-    expect(errors).toEqual([{ keyword: 'columnNameAlreadyUsed', dataPath: '.new_column_name' }]);
   });
 
   it('should validate and emit "formSaved" when submitted data is valid', () => {
@@ -77,13 +35,13 @@ describe('Duplicate Column Step Form', () => {
       store: emptyStore,
       localVue,
       propsData: {
-        initialStepValue: { name: 'duplicate', column: 'foo', new_column_name: 'bar' },
+        initialStepValue: { name: 'duplicate', column: 'foo', new_column_name: '' },
       },
     });
     wrapper.find('.widget-form-action__button--validate').trigger('click');
     expect(wrapper.vm.$data.errors).toBeNull();
     expect(wrapper.emitted()).toEqual({
-      formSaved: [[{ name: 'duplicate', column: 'foo', new_column_name: 'bar' }]],
+      formSaved: [[{ name: 'duplicate', column: 'foo', new_column_name: 'foo_copy' }]],
     });
   });
 

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { castFromString } from '@/lib/helpers';
+import { castFromString, newColumnName } from '@/lib/helpers';
 
 describe('castFromString', () => {
   it('should cast numeric string to number type', () => {
@@ -36,5 +36,17 @@ describe('castFromString', () => {
   it('should not cast a string that does not convert to boolean type', () => {
     const string = 'FaLsE';
     expect(castFromString(string, 'boolean')).toEqual('FaLsE');
+  });
+});
+
+describe('newColumName', () => {
+  it('should return a valid new column name', () => {
+    const existingNames = ['bar'];
+    const newName = 'foo';
+    expect(newColumnName(newName, existingNames)).toEqual('foo');
+    existingNames.push('foo');
+    expect(newColumnName(newName, existingNames)).toEqual('foo1');
+    existingNames.push('foo1');
+    expect(newColumnName(newName, existingNames)).toEqual('foo2');
   });
 });

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -77,7 +77,7 @@ describe('Labeller', () => {
       column: 'column1',
       new_column_name: 'column2',
     };
-    expect(hrl(step)).toEqual('Duplicate "column1" in "column2"');
+    expect(hrl(step)).toEqual('Duplicate "column1"');
   });
 
   it('generates label for delete steps', () => {


### PR DESCRIPTION
Do not ask for a new column name. We choose it for the user, then
the user can apply a rename step if needed. This makes the
workflow more direct (no need to fill a form at step creation)

This PR proposes to introduce a helper function to enforce valid column names when naming is automatic.

Closes https://github.com/ToucanToco/vue-query-builder/issues/314