### PR TITLE
FIX :: Firefox didn't display dataviewer td border

### DIFF
--- a/src/styles/DataViewer.scss
+++ b/src/styles/DataViewer.scss
@@ -11,7 +11,8 @@
 }
 
 .data-viewer-table {
-  border-collapse: collapse;
+  border-right: 1px solid $data-viewer-border-color;
+  border-spacing: 0;
   width: 100%;
 }
 
@@ -22,30 +23,30 @@
   background-color: white;
   cursor: pointer;
   border: 1px solid $data-viewer-border-color;
+  border-bottom-color: transparent;
+  border-right-color: transparent;
   font-size: 13px;
   text-align: left;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: pre;
-  flex-grow: 1;
-  flex-shrink: 0;
-  justify-content: space-between;
-  align-items: center;
 }
 
 .data-viewer-cell {
   background-color: #fafafa;
 }
 
+.data-viewer__header-cell--active,
 .data-viewer-cell--active {
-  // It's trick to have its left side colored cause of border-collapse
-  border-left: 1px double;
   background-color: $active-color-faded-3;
   border-right-color: $active-color;
   border-left-color: $active-color;
 }
 
 .data-viewer__row:last-child {
+  .data-viewer-cell {
+    border-bottom-color: $data-viewer-border-color;
+  }
   .data-viewer-cell--active {
     border-bottom-color: $active-color;
   }
@@ -57,14 +58,8 @@
 }
 
 .data-viewer__header-cell--active {
-  // It's trick to have its left side colored cause of border-collapse
-  border-left: 1px double;
-  color: $active-color;
-  background-color: $active-color-faded-3;
   border-top-color: $active-color;
-  border-left-color: $active-color;
-  border-right-color: $active-color;
-
+  color: $active-color;
   .data-viewer__header-action:hover {
     background-color: $active-color-faded-2;
   }


### PR DESCRIPTION
There was a display issue on FF due to the css property `border-collapse: collapse;` on dataviewer table, HTML element `td` borders were hidden. It was due to a old known bug (not fixed) with border-collapse in Firefox.

To fix it we replace border-collapse with `border-spacing: 0;` and change a bit of css to reproduce the same border style in Firefox and all browsers.

before (FF) : 
![image](https://user-images.githubusercontent.com/4438175/65887171-cf5f2300-e39d-11e9-8829-d0e1850cd8f8.png)

Now (FF) : 
![image](https://user-images.githubusercontent.com/4438175/65888134-506aea00-e39f-11e9-8cab-cd2475ad5faa.png)


