### PR TITLE
Simplify unpivot step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Added variable interpolation handling
 
+### Changed
+
+- Simplify `unpivot` step UX by enforcing automatic column names for
+  `unpivot_column_name` and `value_column_name` (not requiring for a user input
+  anymore)
+
 ## [0.2.0] - 2010-09-26
 
 ### Added

--- a/src/components/stepforms/UnpivotStepForm.vue
+++ b/src/components/stepforms/UnpivotStepForm.vue
@@ -21,22 +21,6 @@
       data-path=".unpivot"
       :errors="errors"
     ></MultiselectWidget>
-    <InputTextWidget
-      id="unpivotColumnNameInput"
-      v-model="editedStep.unpivot_column_name"
-      name="Category column name"
-      placeholder="Enter a column name"
-      data-path=".unpivot_column_name"
-      :errors="errors"
-    ></InputTextWidget>
-    <InputTextWidget
-      id="valueColumnNameInput"
-      v-model="editedStep.value_column_name"
-      name="Value column name"
-      placeholder="Enter a column name"
-      data-path=".value_column_name"
-      :errors="errors"
-    ></InputTextWidget>
     <CheckboxWidget id="dropnaCheckbox" :label="checkboxLabel" v-model="editedStep.dropna"></CheckboxWidget>
     <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
   </div>
@@ -46,17 +30,16 @@
 import { Prop } from 'vue-property-decorator';
 import { StepFormComponent } from '@/components/formlib';
 import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
-import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import BaseStepForm from './StepForm.vue';
 import { UnpivotStep } from '@/lib/steps';
+import { generateNewColumnName } from '@/lib/helpers';
 
 @StepFormComponent({
   vqbstep: 'unpivot',
   name: 'unpivot-step-form',
   components: {
     CheckboxWidget,
-    InputTextWidget,
     MultiselectWidget,
   },
 })
@@ -77,61 +60,10 @@ export default class UnpivotStepForm extends BaseStepForm<UnpivotStep> {
   readonly title: string = 'Unpivot columns';
   readonly checkboxLabel: string = 'Drop null values';
 
-  validate() {
-    const errors = this.$$super.validate();
-    if (errors !== null) {
-      return errors;
-    }
-    const ambiguousColumns = this.editedStep.keep
-      .filter(colname => this.editedStep.unpivot.includes(colname))
-      .sort();
-    if (ambiguousColumns.length) {
-      return [
-        {
-          params: [],
-          schemaPath: '.unpivot',
-          keyword: 'columnNameConflict',
-          dataPath: '.unpivot',
-          message: `Column names ${ambiguousColumns.join(
-            ',',
-          )} were used for both "keep" and "unpivot" fields`,
-        },
-      ];
-    }
-    if (
-      this.editedStep.unpivot_column_name === this.editedStep.value_column_name ||
-      this.editedStep.keep.includes(this.editedStep.unpivot_column_name) ||
-      this.editedStep.unpivot.includes(this.editedStep.unpivot_column_name)
-    ) {
-      return [
-        {
-          params: [],
-          schemaPath: '.unpivot_column_name',
-          keyword: 'columnNameConflict',
-          dataPath: '.unpivot_column_name',
-          message: `Column name ${
-            this.editedStep.unpivot_column_name
-          } is used at least twice but should be unique`,
-        },
-      ];
-    }
-    if (
-      this.editedStep.keep.includes(this.editedStep.value_column_name) ||
-      this.editedStep.unpivot.includes(this.editedStep.value_column_name)
-    ) {
-      return [
-        {
-          params: [],
-          schemaPath: '.value_column_name',
-          keyword: 'columnNameConflict',
-          dataPath: '.value_column_name',
-          message: `Column name ${
-            this.editedStep.value_column_name
-          } is used at least twice but should be unique`,
-        },
-      ];
-    }
-    return null;
+  submit() {
+    this.editedStep.unpivot_column_name = generateNewColumnName('variable', this.columnNames);
+    this.editedStep.value_column_name = generateNewColumnName('value', this.columnNames);
+    this.$$super.submit();
   }
 }
 </script>

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -27,3 +27,21 @@ export function castFromString(value: string, type: DataSetColumnType) {
   }
   return value;
 }
+
+/**
+ * Takes a proposed new column name and returns a valid name that does not erase
+ * an existing column name. So if the proposed new name already exists in
+ * existing columns names, it appends an integer that increments until the new
+ * name becomes unique.
+ *
+ * @param newName the proposed new column name
+ * @param existingNames the existing columns names
+ */
+export function generateNewColumnName(newName: string, existingNames: string[]): string {
+  let i = 1;
+  let validNewName = newName;
+  while (existingNames.includes(validNewName)) {
+    validNewName = `${newName}${i++}`;
+  }
+  return validNewName;
+}

--- a/tests/unit/helpers.spec.ts
+++ b/tests/unit/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { castFromString } from '@/lib/helpers';
+import { castFromString, generateNewColumnName } from '@/lib/helpers';
 
 describe('castFromString', () => {
   it('should cast numeric string to number type', () => {
@@ -36,5 +36,17 @@ describe('castFromString', () => {
   it('should not cast a string that does not convert to boolean type', () => {
     const string = 'FaLsE';
     expect(castFromString(string, 'boolean')).toEqual('FaLsE');
+  });
+
+  describe('generateNewColumnName', () => {
+    it('should return a valid new column name', () => {
+      const existingNames = ['bar'];
+      const newName = 'foo';
+      expect(generateNewColumnName(newName, existingNames)).toEqual('foo');
+      existingNames.push('foo');
+      expect(generateNewColumnName(newName, existingNames)).toEqual('foo1');
+      existingNames.push('foo1');
+      expect(generateNewColumnName(newName, existingNames)).toEqual('foo2');
+    });
   });
 });

--- a/tests/unit/unpivot-step-form.spec.ts
+++ b/tests/unit/unpivot-step-form.spec.ts
@@ -25,12 +25,10 @@ describe('Unpivot Step Form', () => {
     expect(wrapper.exists()).toBeTruthy();
   });
 
-  it('should have 5 input components', () => {
+  it('should have 3 input components', () => {
     const wrapper = shallowMount(UnpivotStepForm, { store: emptyStore, localVue });
     const autocompleteWrappers = wrapper.findAll('multiselectwidget-stub');
     expect(autocompleteWrappers.length).toEqual(2);
-    const inputWrappers = wrapper.findAll('inputtextwidget-stub');
-    expect(inputWrappers.length).toEqual(2);
     const checkboxWrappers = wrapper.findAll('checkboxwidget-stub');
     expect(checkboxWrappers.length).toEqual(1);
   });
@@ -54,8 +52,6 @@ describe('Unpivot Step Form', () => {
     });
     expect(wrapper.find('#keepColumnInput').props('value')).toEqual(['foo', 'bar']);
     expect(wrapper.find('#unpivotColumnInput').props('value')).toEqual(['baz']);
-    expect(wrapper.find('#unpivotColumnNameInput').props('value')).toEqual('spam');
-    expect(wrapper.find('#valueColumnNameInput').props('value')).toEqual('eggs');
     const widgetCheckbox = wrapper.find(CheckboxWidget);
     expect(widgetCheckbox.classes()).not.toContain('widget-checkbox--checked');
   });
@@ -89,112 +85,8 @@ describe('Unpivot Step Form', () => {
       expect(errors).toEqual([
         { keyword: 'minItems', dataPath: '.keep' },
         { keyword: 'minItems', dataPath: '.unpivot' },
-        { keyword: 'minLength', dataPath: '.unpivot_column_name' },
-        { keyword: 'minLength', dataPath: '.value_column_name' },
       ]);
     });
-
-    it('should report errors when keep and unpivot column names overlap', async () => {
-      const store = setupMockStore({
-        dataset: {
-          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-          data: [],
-        },
-      });
-      const wrapper = mount(UnpivotStepForm, { store, localVue });
-      wrapper.setData({
-        editedStep: {
-          name: 'unpivot',
-          keep: ['columnA', 'columnC'],
-          unpivot: ['columnA', 'columnB', 'columnC'],
-          unpivot_column_name: 'foo',
-          value_column_name: 'bar',
-          dropna: true,
-        },
-      });
-      wrapper.find('.widget-form-action__button--validate').trigger('click');
-      await localVue.nextTick();
-      const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-        keyword: err.keyword,
-        dataPath: err.dataPath,
-        message: err.message,
-      }));
-      expect(errors).toEqual([
-        {
-          keyword: 'columnNameConflict',
-          dataPath: '.unpivot',
-          message: 'Column names columnA,columnC were used for both "keep" and "unpivot" fields',
-        },
-      ]);
-    });
-
-    it('should report errors when the unpivot_column_name value is already used', async () => {
-      const store = setupMockStore({
-        dataset: {
-          headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-          data: [],
-        },
-      });
-      const wrapper = mount(UnpivotStepForm, { store, localVue });
-      wrapper.setData({
-        editedStep: {
-          name: 'unpivot',
-          keep: ['columnA'],
-          unpivot: ['columnB', 'columnC'],
-          unpivot_column_name: 'columnA',
-          value_column_name: 'bar',
-          dropna: true,
-        },
-      });
-      wrapper.find('.widget-form-action__button--validate').trigger('click');
-      await localVue.nextTick();
-      const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-        keyword: err.keyword,
-        dataPath: err.dataPath,
-        message: err.message,
-      }));
-      expect(errors).toEqual([
-        {
-          keyword: 'columnNameConflict',
-          dataPath: '.unpivot_column_name',
-          message: 'Column name columnA is used at least twice but should be unique',
-        },
-      ]);
-    });
-  });
-
-  it('should report errors when the value_column_name value is already used', async () => {
-    const store = setupMockStore({
-      dataset: {
-        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
-        data: [],
-      },
-    });
-    const wrapper = mount(UnpivotStepForm, { store, localVue });
-    wrapper.setData({
-      editedStep: {
-        name: 'unpivot',
-        keep: ['columnA'],
-        unpivot: ['columnB', 'columnC'],
-        unpivot_column_name: 'foo',
-        value_column_name: 'columnB',
-        dropna: true,
-      },
-    });
-    wrapper.find('.widget-form-action__button--validate').trigger('click');
-    await localVue.nextTick();
-    const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
-      keyword: err.keyword,
-      dataPath: err.dataPath,
-      message: err.message,
-    }));
-    expect(errors).toEqual([
-      {
-        keyword: 'columnNameConflict',
-        dataPath: '.value_column_name',
-        message: 'Column name columnB is used at least twice but should be unique',
-      },
-    ]);
   });
 
   it('should validate and emit "formSaved" when submitted data is valid', async () => {
@@ -206,8 +98,6 @@ describe('Unpivot Step Form', () => {
           name: 'unpivot',
           keep: ['columnA', 'columnB'],
           unpivot: ['columnC'],
-          unpivot_column_name: 'foo',
-          value_column_name: 'bar',
           dropna: true,
         },
       },
@@ -222,8 +112,8 @@ describe('Unpivot Step Form', () => {
             name: 'unpivot',
             keep: ['columnA', 'columnB'],
             unpivot: ['columnC'],
-            unpivot_column_name: 'foo',
-            value_column_name: 'bar',
+            unpivot_column_name: 'variable',
+            value_column_name: 'value',
             dropna: true,
           },
         ],


### PR DESCRIPTION
Do not require to specify the value_column_name or category_column_name.
The meaning of those parameters was not clear.
We can enforce a name to make the UX more straightforward, and if needed the user can apply a rename step.

Closes https://github.com/ToucanToco/vue-query-builder/issues/304