### PR TITLE
Fix :: Top step initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   `unpivot_column_name` and `value_column_name` (not requiring for a user input
   anymore)
 
+### Fixed
+
+- Fixed `top` step initialization (`rank_on` parameter)
+
 ## [0.2.0] - 2010-09-26
 
 ### Added

--- a/src/components/stepforms/TopStepForm.vue
+++ b/src/components/stepforms/TopStepForm.vue
@@ -66,5 +66,16 @@ export default class TopStepForm extends BaseStepForm<TopStep> {
   initialStepValue!: TopStep;
 
   readonly title: string = 'Top N rows';
+
+  get stepSelectedColumn() {
+    return this.editedStep.rank_on;
+  }
+
+  set stepSelectedColumn(colname: string | null) {
+    if (colname === null) {
+      throw new Error('should not try to set null on top "rank_on" field');
+    }
+    this.editedStep.rank_on = colname;
+  }
 }
 </script>


### PR DESCRIPTION
The `rank_on` parameter was not properly initialized.

Closes https://github.com/ToucanToco/vue-query-builder/issues/283