### PR TITLE
Feature :: concatenate step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 ### Added
 
 - Added variable interpolation + autocast handling
-- Added `lowercase`step
-- Added `uppercase`step
+- Added `lowercase` step
+- Added `uppercase` step
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,17 @@
 ## [Unreleased]
 
 ## Fixed
+
 - Fixed closing popover on ActionButton when opening one on column header cell
 
 ### Changed
 
 - Simplify lowercase and uppercase UI workflow (no need to open form when a
   column is selected)
+
+### Added
+
+- Added concatenate step
 
 ## [0.3.0] - 2010-10-08
 

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -458,6 +458,44 @@ Column names must not be escaped. Strings have to be escaped with quotes.
 | Label 2 | 1      | 13     | 7      | 3      | -4     |
 | Label 3 | 5      | 20     | 5      | 2      | 1      |
 
+### `lowercase` step
+
+Converts a string `column` to lowercase.
+
+```javascript
+{
+  name: 'lowercase',
+  column: 'foo',
+}
+```
+
+#### Example:
+
+**Input dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| Label 1 | Group 1 | 13    |
+| Label 2 | Group 1 | 7     |
+| Label 3 | Group 1 | 20    |
+
+**Step configuration:**
+
+```javascript
+{
+  name: 'lowercase',
+  column: 'Label',
+}
+```
+
+**Output dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| label 1 | Group 1 | 13    |
+| label 2 | Group 1 | 7     |
+| label 3 | Group 1 | 20    |
+
 ### `percentage` step
 
 Compute the percentage of total, i.e. for every row the value in `column` divided
@@ -745,44 +783,6 @@ When sorting on several columns, order of columns specified in `columns` matters
 | Label 6 | Group 2 | 5     |
 | Label 4 | Group 2 | 1     |
 
-### `lowercase` step
-
-Converts a string `column` to lowercase.
-
-```javascript
-{
-  name: 'lowercase',
-  column: 'foo',
-}
-```
-
-#### Example:
-
-**Input dataset:**
-
-| Label   | Group   | Value |
-| ------- | ------- | ----- |
-| Label 1 | Group 1 | 13    |
-| Label 2 | Group 1 | 7     |
-| Label 3 | Group 1 | 20    |
-
-**Step configuration:**
-
-```javascript
-{
-  name: 'lowercase',
-  column: 'Label',
-}
-```
-
-**Output dataset:**
-
-| Label   | Group   | Value |
-| ------- | ------- | ----- |
-| label 1 | Group 1 | 13    |
-| label 2 | Group 1 | 7     |
-| label 3 | Group 1 | 20    |
-
 ### `top` step
 
 Return top N rows by group if `groups` is specified, else over full dataset.
@@ -860,44 +860,6 @@ Return top N rows by group if `groups` is specified, else over full dataset.
 | ------- | ------- | ----- |
 | Label 3 | Group 1 | 20    |
 | Label 5 | Group 2 | 10    |
-
-### `uppercase` step
-
-Converts a string `column` to uppercase.
-
-```javascript
-{
-  name: 'uppercase',
-  column: 'foo',
-}
-```
-
-#### Example:
-
-**Input dataset:**
-
-| Label   | Group   | Value |
-| ------- | ------- | ----- |
-| Label 1 | Group 1 | 13    |
-| Label 2 | Group 1 | 7     |
-| Label 3 | Group 1 | 20    |
-
-**Step configuration:**
-
-```javascript
-{
-  name: 'uppercase',
-  column: 'Label',
-}
-```
-
-**Output dataset:**
-
-| Label   | Group   | Value |
-| ------- | ------- | ----- |
-| LABEL 1 | Group 1 | 13    |
-| LABEL 2 | Group 1 | 7     |
-| LABEL 3 | Group 1 | 20    |
 
 ### `unpivot` step
 
@@ -986,3 +948,41 @@ Unpivot a list of columns to rows.
 | Company 1 | USA     | REVENUES   | 6     |
 | Company 2 | USA     | NB_CLIENTS | 1     |
 | Company 2 | USA     | REVENUES   | 3     |
+
+### `uppercase` step
+
+Converts a string `column` to uppercase.
+
+```javascript
+{
+  name: 'uppercase',
+  column: 'foo',
+}
+```
+
+#### Example:
+
+**Input dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| Label 1 | Group 1 | 13    |
+| Label 2 | Group 1 | 7     |
+| Label 3 | Group 1 | 20    |
+
+**Step configuration:**
+
+```javascript
+{
+  name: 'uppercase',
+  column: 'Label',
+}
+```
+
+**Output dataset:**
+
+| Label   | Group   | Value |
+| ------- | ------- | ----- |
+| LABEL 1 | Group 1 | 13    |
+| LABEL 2 | Group 1 | 7     |
+| LABEL 3 | Group 1 | 20    |

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -211,6 +211,54 @@ is specified.
 | Label 2 | Group 1 | 7     |
 | Label 4 | Group 2 | 1     |
 
+### `concatenate` step
+
+This step allows to concatenate several `columns` using a `separator`.
+
+```javascript
+{
+  name: 'concatenate',
+  columns: ['Company', 'Group']
+  separator: ' - ' // can be a string of any length
+  new_column_name: 'Label' // The new column in which to write the concatenation
+}
+```
+
+#### Example
+
+**Input dataset:**
+
+| Company   | Group   | Value |
+| --------- | ------- | ----- |
+| Company 1 | Group 1 | 13    |
+| Company 2 | Group 1 | 7     |
+| Company 3 | Group 1 | 20    |
+| Company 4 | Group 2 | 1     |
+| Company 5 | Group 2 | 10    |
+| Company 6 | Group 2 | 5     |
+
+**Step configuration:**
+
+```javascript
+{
+  name: 'concatenate',
+  columns: ['Company', 'Group']
+  separator: ' - '
+  new_column_name: 'Label'
+}
+```
+
+**Output dataset:**
+
+| Company   | Group   | Value | Label               |
+| --------- | ------- | ----- | ------------------- |
+| Company 1 | Group 1 | 13    | Company 1 - Group 1 |
+| Company 2 | Group 1 | 7     | Company 2 - Group 1 |
+| Company 3 | Group 1 | 20    | Company 3 - Group 1 |
+| Company 4 | Group 2 | 1     | Company 4 - Group 2 |
+| Company 5 | Group 2 | 10    | Company 5 - Group 2 |
+| Company 6 | Group 2 | 5     | Company 6 - Group 2 |
+
 ### `custom` step
 
 This step allows to define a custom query that can't be expressed using the

--- a/src/components/ActionToolbarButton.vue
+++ b/src/components/ActionToolbarButton.vue
@@ -1,6 +1,6 @@
 <template>
   <button type="button" class="action-toolbar__btn">
-    <i :class="`action-toolbar__btn-icon fas fa-${icon}`"/>
+    <i :class="`action-toolbar__btn-icon fas fa-${icon}`" />
     <span class="action-toolbar__btn-txt">{{ label }}</span>
     <popover :active="isActive" :align="'left'" bottom>
       <div class="action-menu__body">
@@ -62,7 +62,7 @@ export default class ActionToolbarButton extends Vue {
   /**
    * @description Close the popover when clicking outside
    */
-  clickListener(e: Event ) {
+  clickListener(e: Event) {
     const target = e.target as HTMLElement;
     const hasClickOnItSelf = target === this.$el || this.$el.contains(target);
 

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -36,11 +36,12 @@ export const ACTION_CATEGORIES: ActionCategories = {
     { name: 'argmax', label: 'Argmax' },
     { name: 'argmin', label: 'Argmin' },
   ],
-  reshape: [{ name: 'pivot', label: 'Pivot' }, { name: 'unpivot', label: 'Unpivot' }],
   text: [
+    { name: 'concatenate', label: 'Concatenate' },
     { name: 'lowercase', label: 'To lowercase' },
     { name: 'uppercase', label: 'To uppercase' },
   ],
+  reshape: [{ name: 'pivot', label: 'Pivot' }, { name: 'unpivot', label: 'Unpivot' }],
 };
 
 export const SEARCH_ACTION: groupActions[] = [

--- a/src/components/stepforms/ColumnPicker.vue
+++ b/src/components/stepforms/ColumnPicker.vue
@@ -40,6 +40,11 @@ export default class ColumnPicker extends Vue {
   @Prop({ default: null })
   dataPath!: string;
 
+  // Whether the column data of ColumnPicker should react to a change of
+  // selected column
+  @Prop({ default: true })
+  syncWithSelectedColumn!: boolean;
+
   // Only manage the deletion of 1 column at once at this stage
   column: string | null = null;
 
@@ -69,7 +74,7 @@ export default class ColumnPicker extends Vue {
 
   @Watch('selectedColumns')
   onSelectedColumnsChanged(val: string[], oldVal: string[]) {
-    if (!_.isEqual(val, oldVal)) {
+    if (!_.isEqual(val, oldVal) && this.syncWithSelectedColumn) {
       this.column = val[0];
     }
   }

--- a/src/components/stepforms/ConcatenateStepForm.vue
+++ b/src/components/stepforms/ConcatenateStepForm.vue
@@ -1,0 +1,91 @@
+<template>
+  <div>
+    <step-form-title :title="title"></step-form-title>
+    <ListWidget
+      addFieldName="Add columns"
+      id="toConcatenate"
+      name="Columns to concatenate:"
+      v-model="toConcatenate"
+      :defaultItem="[]"
+      :widget="columnPicker"
+      :componentProps="{ syncWithSelectedColumn: false }"
+      :automatic-new-field="false"
+      data-path=".columns"
+      :errors="errors"
+    ></ListWidget>
+    <InputTextWidget
+      id="separator"
+      v-model="editedStep.separator"
+      name="Separator:"
+      placeholder="Enter string of any length"
+      data-path=".separator"
+      :errors="errors"
+    ></InputTextWidget>
+    <InputTextWidget
+      id="newColumnName"
+      v-model="editedStep.new_column_name"
+      name="New column name:"
+      placeholder="Enter a columnn name"
+      data-path=".new_column_name"
+      :errors="errors"
+    ></InputTextWidget>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+  </div>
+</template>
+
+<script lang="ts">
+import { Prop } from 'vue-property-decorator';
+import { StepFormComponent } from '@/components/formlib';
+import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+import ListWidget from '@/components/stepforms/widgets/List.vue';
+import BaseStepForm from './StepForm.vue';
+import { ConcatenateStep } from '@/lib/steps';
+
+@StepFormComponent({
+  vqbstep: 'concatenate',
+  name: 'concatenate-step-form',
+  components: {
+    ColumnPicker,
+    InputTextWidget,
+    ListWidget,
+  },
+})
+export default class ConcatenateStepForm extends BaseStepForm<ConcatenateStep> {
+  @Prop({
+    type: Object,
+    default: () => ({ name: 'concatenate', columns: [''], separator: '', new_column_name: '' }),
+  })
+  initialStepValue!: ConcatenateStep;
+
+  readonly title: string = 'Concatenate columns';
+  columnPicker = ColumnPicker;
+
+  mounted() {
+    // If a column is selected, use it to set the first "column" property
+    if (this.isStepCreation && this.selectedColumns[0]) {
+      this.editedStep = {
+        name: 'concatenate' as 'concatenate',
+        columns: [this.selectedColumns[0]],
+        separator: '',
+        new_column_name: '',
+      };
+    } else {
+      // Otherwise, fallback on the default initial value
+      this.editedStep = { ...this.initialStepValue };
+    }
+  }
+
+  get toConcatenate() {
+    if (this.editedStep.columns.length) {
+      return this.editedStep.columns;
+    } else {
+      return [''];
+    }
+  }
+
+  set toConcatenate(newval) {
+    this.editedStep.columns = [...newval];
+  }
+}
+</script>

--- a/src/components/stepforms/ConcatenateStepForm.vue
+++ b/src/components/stepforms/ConcatenateStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <step-form-title :title="title"></step-form-title>
+    <step-form-title :title="title" />
     <ListWidget
       addFieldName="Add columns"
       id="toConcatenate"
@@ -12,7 +12,7 @@
       :automatic-new-field="false"
       data-path=".columns"
       :errors="errors"
-    ></ListWidget>
+    />
     <InputTextWidget
       id="separator"
       v-model="editedStep.separator"
@@ -20,7 +20,7 @@
       placeholder="Enter string of any length"
       data-path=".separator"
       :errors="errors"
-    ></InputTextWidget>
+    />
     <InputTextWidget
       id="newColumnName"
       v-model="editedStep.new_column_name"
@@ -28,8 +28,8 @@
       placeholder="Enter a columnn name"
       data-path=".new_column_name"
       :errors="errors"
-    ></InputTextWidget>
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    />
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit" />
   </div>
 </template>
 

--- a/src/components/stepforms/index.ts
+++ b/src/components/stepforms/index.ts
@@ -1,6 +1,7 @@
 import './AggregateStepForm.vue';
 import './ArgminStepForm.vue';
 import './ArgmaxStepForm.vue';
+import './ConcatenateStepForm.vue';
 import './DeleteColumnStepForm.vue';
 import './DuplicateColumnStepForm.vue';
 import './DomainStepForm.vue';

--- a/src/components/stepforms/schemas/concatenate.ts
+++ b/src/components/stepforms/schemas/concatenate.ts
@@ -1,0 +1,47 @@
+import { StepFormType, addNotInColumnNamesConstraint } from './utils';
+
+const schema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Concatenate step',
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      enum: ['concatenate'],
+    },
+    columns: {
+      type: 'array',
+      items: {
+        type: ['string'],
+        minLength: 1,
+      },
+      minItems: 1,
+      title: 'To concatenate',
+      description: 'Columns to concatenate',
+    },
+    separator: {
+      type: 'string',
+      minLength: 0,
+      title: 'Separator',
+      description: 'The separator used to concatenate strings',
+      attrs: {
+        placeholder: 'Enter a string of any length',
+      },
+    },
+    new_column_name: {
+      type: 'string',
+      minLength: 1,
+      title: 'New column name',
+      description: 'The new column that will be created with the concatenated string',
+      attrs: {
+        placeholder: 'Enter a column name',
+      },
+    },
+  },
+  required: ['name', 'columns', 'separator', 'new_column_name'],
+  additionalProperties: false,
+};
+
+export default function buildSchema(form: StepFormType) {
+  return addNotInColumnNamesConstraint(schema, 'new_column_name', form.columnNames);
+}

--- a/src/components/stepforms/schemas/index.ts
+++ b/src/components/stepforms/schemas/index.ts
@@ -1,6 +1,7 @@
 import aggregateBuildSchema from './aggregate';
 import argmaxSchema from './argmax';
 import argminSchema from './argmin';
+import concatenateBuildSchema from './concatenate';
 import deleteSchema from './delete';
 import duplicateSchema from './duplicate';
 import domainSchema from './domain';
@@ -24,6 +25,7 @@ const factories: { [stepname: string]: buildSchemaType } = {
   aggregate: aggregateBuildSchema,
   argmax: argmaxSchema,
   argmin: argminSchema,
+  concatenate: concatenateBuildSchema,
   delete: deleteSchema,
   duplicate: duplicateSchema,
   domain: domainSchema,

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -10,18 +10,23 @@
         <div class="widget-list__component">
           <component
             :is="widget"
+            v-bind="componentProps"
             :value="child.value"
             @input="updateChildValue($event, index)"
             :data-path="`${dataPath}[${index}]`"
-            :errors="errors"/>
+            :errors="errors"
+          />
         </div>
         <div class="widget-list__icon" v-if="child.isRemovable" @click="removeChild(index)">
-          <i class="far fa-trash-alt"/>
+          <i class="far fa-trash-alt" />
         </div>
       </div>
-      <div v-if="messageError" class="field__msg-error"><span class="fa fa-exclamation-circle"/>{{ messageError }}</div>
+      <div v-if="messageError" class="field__msg-error">
+        <span class="fa fa-exclamation-circle" />
+        {{ messageError }}
+      </div>
       <button v-if="!automaticNewField" class="widget-list__add-fieldset" @click="addFieldSet">
-        <i class="fas fa-plus-circle"/>
+        <i class="fas fa-plus-circle" />
         {{ addFieldName }}
       </button>
     </div>
@@ -50,6 +55,9 @@ type RepeatableField = Field[];
 export default class ListWidget extends Mixins(FormWidget) {
   @Prop({ type: String, default: '' })
   addFieldName!: string;
+
+  @Prop({ type: Object, default: () => { } })
+  componentProps!: object;
 
   @Prop({ type: String, default: null })
   id!: string;

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -105,6 +105,10 @@ class StepLabeller implements StepMatcher<string> {
     return `Keep row with minimum in column "${step.column}"`;
   }
 
+  concatenate(step: Readonly<S.ConcatenateStep>) {
+    return `Concatenate columns ${formatMulticol(step.columns)}`;
+  }
+
   custom(_step: Readonly<S.CustomStep>) {
     return 'Custom step';
   }

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -34,6 +34,13 @@ export type ArgminStep = {
   groups?: string[]; // if specified, will search for a max in every group
 };
 
+export type ConcatenateStep = {
+  name: 'concatenate';
+  columns: string[];
+  separator: string;
+  new_column_name: string;
+};
+
 export type CustomStep = {
   name: 'custom';
   query: object;
@@ -175,6 +182,7 @@ export type PipelineStep =
   | AggregationStep
   | ArgmaxStep
   | ArgminStep
+  | ConcatenateStep
   | CustomStep
   | DeleteStep
   | DuplicateColumnStep

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -121,6 +121,10 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
     return { ...step };
   }
 
+  concatenate(step: Readonly<S.ConcatenateStep>) {
+    return { ...step };
+  }
+
   custom(step: Readonly<S.CustomStep>) {
     return { ...step };
   }

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -100,6 +100,9 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
   argmin(step: Readonly<S.ArgminStep>) {}
 
   @unsupported
+  concatenate(step: Readonly<S.ConcatenateStep>) {}
+
+  @unsupported
   custom(step: Readonly<S.CustomStep>) {}
 
   @unsupported

--- a/tests/unit/action-toolbar-button.spec.ts
+++ b/tests/unit/action-toolbar-button.spec.ts
@@ -37,13 +37,20 @@ describe('ActionToolbar', () => {
     expect(wrapper.emitted().actionClicked[1]).toEqual(['percentage']);
   });
 
-  it('should instantiate a Compute button with the right list of actions', () => {
+  it('should instantiate a Text button with the right list of actions', () => {
     const wrapper = mount(ActionToolbarButton, { propsData: { category: 'text' } });
     expect(wrapper.exists()).toBeTruthy();
     const actionsWrappers = wrapper.findAll('.action-menu__option');
-    expect(actionsWrappers.length).toEqual(2);
-    expect(actionsWrappers.at(0).text()).toEqual('To lowercase');
-    expect(actionsWrappers.at(1).text()).toEqual('To uppercase');
+    expect(actionsWrappers.length).toEqual(3);
+    actionsWrappers.at(0).trigger('click');
+    expect(wrapper.emitted().actionClicked).toHaveLength(1);
+    expect(wrapper.emitted().actionClicked[0]).toEqual(['concatenate']);
+    // clicking on "lowercase" ou "uppercase" should not trigger "actionClicked"
+    // since we don't use an edit form for these steps.
+    actionsWrappers.at(1).trigger('click');
+    expect(wrapper.emitted().actionClicked).toHaveLength(1);
+    actionsWrappers.at(2).trigger('click');
+    expect(wrapper.emitted().actionClicked).toHaveLength(1);
   });
 
   it('should instantiate a Date button with the right list of actions', () => {
@@ -83,7 +90,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(0).trigger('click');
+      await actionsWrappers.at(1).trigger('click');
       expect(store.state.vqb.currentStepFormName).toEqual(undefined);
     });
 
@@ -98,7 +105,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(0).trigger('click');
+      await actionsWrappers.at(1).trigger('click');
       expect(store.state.vqb.pipeline).toEqual([
         { name: 'domain', domain: 'myDomain' },
         { name: 'lowercase', column: 'foo' },
@@ -117,7 +124,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(0).trigger('click');
+      await actionsWrappers.at(1).trigger('click');
       expect(wrapper.emitted().closed).toBeTruthy();
     });
   });
@@ -134,7 +141,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(1).trigger('click');
+      await actionsWrappers.at(2).trigger('click');
       expect(store.state.vqb.currentStepFormName).toEqual(undefined);
     });
 
@@ -149,7 +156,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(1).trigger('click');
+      await actionsWrappers.at(2).trigger('click');
       expect(store.state.vqb.pipeline).toEqual([
         { name: 'domain', domain: 'myDomain' },
         { name: 'uppercase', column: 'foo' },
@@ -168,7 +175,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(1).trigger('click');
+      await actionsWrappers.at(2).trigger('click');
       expect(wrapper.emitted().closed).toBeTruthy();
     });
   });

--- a/tests/unit/action-toolbar.spec.ts
+++ b/tests/unit/action-toolbar.spec.ts
@@ -9,22 +9,6 @@ const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('ActionToolbar', () => {
-  it('should instantiate action toolbar button', () => {
-    const wrapper = shallowMount(ActionToolbar, {
-      propsData: {
-        buttons: [
-          {
-            category: 'filter',
-            icon: 'filter',
-            label: 'Filter',
-          },
-        ],
-      },
-    });
-    const actionButtons = wrapper.findAll('action-toolbar-button-stub');
-    expect(actionButtons.exists()).toBeTruthy();
-  });
-
   it('should instantiate action toolbar buttons with right classes', () => {
     const wrapper = mount(ActionToolbar, {
       propsData: {

--- a/tests/unit/column-picker.spec.ts
+++ b/tests/unit/column-picker.spec.ts
@@ -52,7 +52,7 @@ describe('Column Picker', () => {
     expect(wrapper.vm.$data.column).toEqual('columnA');
   });
 
-  it('should update step when selectedColumn is changed', async () => {
+  it('should update step when selectedColumn is changed by default', async () => {
     const store: Store<any> = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
@@ -68,6 +68,28 @@ describe('Column Picker', () => {
     store.commit(VQBnamespace('setSelectedColumns'), { column: 'columnB' });
     await localVue.nextTick();
     expect(wrapper.vm.$data.column).toEqual('columnB');
+    expect(store.state.vqb.selectedColumns).toEqual(['columnB']);
+  });
+
+  it('should not update step when selectedColumn is changed if prop "sync" is false', async () => {
+    const store: Store<any> = setupMockStore({
+      dataset: {
+        headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
+        data: [],
+      },
+      selectedColumns: ['columnA'],
+    });
+    const wrapper = shallowMount(ColumnPicker, {
+      store,
+      localVue,
+      propsData: {
+        syncWithSelectedColumn: false,
+      },
+    });
+    expect(wrapper.vm.$data.column).toEqual('columnA');
+    store.commit(VQBnamespace('setSelectedColumns'), { column: 'columnB' });
+    await localVue.nextTick();
+    expect(wrapper.vm.$data.column).toEqual('columnA');
     expect(store.state.vqb.selectedColumns).toEqual(['columnB']);
   });
 });

--- a/tests/unit/concatenate-step-form.spec.ts
+++ b/tests/unit/concatenate-step-form.spec.ts
@@ -1,0 +1,134 @@
+import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import ConcatenateStepForm from '@/components/stepforms/ConcatenateStepForm.vue';
+import Vuex, { Store } from 'vuex';
+import { setupMockStore } from './utils';
+import { Pipeline } from '@/lib/steps';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+interface ValidationError {
+  dataPath: string;
+  keyword: string;
+}
+
+describe('Concatenate Step Form', () => {
+  let emptyStore: Store<any>;
+  beforeEach(() => {
+    emptyStore = setupMockStore({});
+  });
+
+  it('should instantiate', () => {
+    const wrapper = shallowMount(ConcatenateStepForm, { store: emptyStore, localVue });
+    expect(wrapper.exists()).toBeTruthy();
+    expect(wrapper.vm.$data.stepname).toEqual('concatenate');
+  });
+
+  describe('ListWidget', () => {
+    it('should have exactly on ListWidget component', () => {
+      const wrapper = shallowMount(ConcatenateStepForm, { store: emptyStore, localVue });
+      const widgetWrappers = wrapper.findAll('listwidget-stub');
+      expect(widgetWrappers.length).toEqual(1);
+    });
+
+    it('should pass down the "toConcatenate" prop to the ListWidget value prop', async () => {
+      const wrapper = shallowMount(ConcatenateStepForm, { store: emptyStore, localVue });
+      wrapper.setData({
+        editedStep: {
+          name: 'concatenate',
+          columns: ['foo', 'bar'],
+          separator: '-',
+          new_column_name: 'new',
+        },
+      });
+      await localVue.nextTick();
+      expect(wrapper.find('listwidget-stub').props().value).toEqual(['foo', 'bar']);
+    });
+  });
+
+  it('should report errors when submitted data is not valid', () => {
+    const store = setupMockStore({
+      dataset: {
+        headers: [{ name: 'foo', type: 'string' }],
+        data: [[null]],
+      },
+    });
+    const wrapper = mount(ConcatenateStepForm, {
+      store,
+      localVue,
+    });
+    wrapper.find('.widget-form-action__button--validate').trigger('click');
+    const errors = wrapper.vm.$data.errors.map((err: ValidationError) => ({
+      keyword: err.keyword,
+      dataPath: err.dataPath,
+    }));
+    expect(errors).toEqual([
+      { dataPath: '.columns[0]', keyword: 'minLength' },
+      { dataPath: '.new_column_name', keyword: 'minLength' },
+    ]);
+  });
+
+  it('should validate and emit "formSaved" when submitting a valid condition', () => {
+    const store = setupMockStore({
+      dataset: {
+        headers: [{ name: 'foo', type: 'string' }, { name: 'bar', type: 'string' }],
+        data: [[null], [null]],
+      },
+    });
+    const wrapper = mount(ConcatenateStepForm, {
+      store,
+      localVue,
+      sync: false,
+      propsData: {
+        initialStepValue: {
+          name: 'concatenate',
+          columns: ['foo', 'bar'],
+          separator: '-',
+          new_column_name: 'new',
+        },
+      },
+    });
+    wrapper.find('.widget-form-action__button--validate').trigger('click');
+    expect(wrapper.vm.$data.errors).toBeNull();
+    expect(wrapper.emitted()).toEqual({
+      formSaved: [
+        [
+          {
+            name: 'concatenate',
+            columns: ['foo', 'bar'],
+            separator: '-',
+            new_column_name: 'new',
+          },
+        ],
+      ],
+    });
+  });
+
+  it('should emit "cancel" event when edition is cancelled', () => {
+    const wrapper = mount(ConcatenateStepForm, { store: emptyStore, localVue });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    expect(wrapper.emitted()).toEqual({
+      cancel: [[]],
+    });
+  });
+
+  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+      { name: 'rename', oldname: 'baz', newname: 'spam' },
+      { name: 'rename', oldname: 'tic', newname: 'tac' },
+    ];
+    const store: Store<any> = setupMockStore({
+      pipeline,
+      selectedStepIndex: 2,
+    });
+    const wrapper = mount(ConcatenateStepForm, { store, localVue });
+    wrapper.setProps({ isStepCreation: true });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    expect(store.state.vqb.selectedStepIndex).toEqual(2);
+    wrapper.setProps({ isStepCreation: false });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    expect(store.state.vqb.selectedStepIndex).toEqual(3);
+  });
+});

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -55,6 +55,16 @@ describe('Labeller', () => {
     expect(hrl(step)).toEqual('Keep row with minimum in column "column1"');
   });
 
+  it('generates label for concatenate steps', () => {
+    const step: S.ConcatenateStep = {
+      name: 'concatenate',
+      columns: ['Foo', 'Bar'],
+      separator: '',
+      new_column_name: 'whatever',
+    };
+    expect(hrl(step)).toEqual('Concatenate columns "Foo", "Bar"');
+  });
+
   it('generates label for custom steps', () => {
     const step: S.CustomStep = {
       name: 'custom',

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -1259,4 +1259,36 @@ describe('Pipeline to mongo translator', () => {
       { $project: { _id: 0 } },
     ]);
   });
+
+  it('can generate a concatenate step with only one column', () => {
+    const pipeline: Pipeline = [
+      {
+        name: 'concatenate',
+        columns: ['foo'],
+        separator: ' - ',
+        new_column_name: 'concat',
+      },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      { $addFields: { concat: { $concat: ['$foo'] } } },
+      { $project: { _id: 0 } },
+    ]);
+  });
+
+  it('can generate a concatenate step with at least two columns', () => {
+    const pipeline: Pipeline = [
+      {
+        name: 'concatenate',
+        columns: ['foo', 'bar', 'again'],
+        separator: ' - ',
+        new_column_name: 'concat',
+      },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      { $addFields: { concat: { $concat: ['$foo', ' - ', '$bar', ' - ', '$again'] } } },
+      { $project: { _id: 0 } },
+    ]);
+  });
 });

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -63,6 +63,18 @@ describe('Pipeline interpolator', () => {
     expect(translate(pipeline)).toEqual(pipeline);
   });
 
+  it('should leave concatenate steps untouched', () => {
+    const pipeline: Pipeline = [
+      {
+        name: 'concatenate',
+        columns: ['<%= foo %>', '<%= bar %>'],
+        separator: '',
+        new_column_name: 'new',
+      },
+    ];
+    expect(translate(pipeline)).toEqual(pipeline);
+  });
+
   it('should leave custom steps untouched', () => {
     const pipeline: Pipeline = [
       {


### PR DESCRIPTION
Introduce a `concatenate` step translated into mongo.
Allows concatenating several columns using a separator of the user's choice.

Closes https://github.com/ToucanToco/vue-query-builder/issues/340