### PR TITLE
Fix labelling and bad interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - Fixed `top` step initialization (`rank_on` parameter)
+- Fixed `argmin` and `argmax` labelling, initialization and interactions
 
 ## [0.2.0] - 2010-09-26
 

--- a/src/components/stepforms/ArgmaxStepForm.vue
+++ b/src/components/stepforms/ArgmaxStepForm.vue
@@ -4,7 +4,7 @@
     <ColumnPicker
       id="valueColumnInput"
       v-model="editedStep.column"
-      name="Search min value in..."
+      name="Search max value in..."
       placeholder="Enter a column name"
       data-path=".column"
       :errors="errors"
@@ -14,7 +14,6 @@
       v-model="editedStep.groups"
       name="(Optional) Group by..."
       :options="columnNames"
-      @input="setSelectedColumns({ column: editedStep.groups[editedStep.groups.length-1] })"
       placeholder="Add columns"
       data-path=".groups"
       :errors="errors"
@@ -44,5 +43,16 @@ export default class ArgmaxStepForm extends BaseStepForm<ArgmaxStep> {
   initialStepValue!: ArgmaxStep;
 
   readonly title: string = 'Argmax';
+
+  get stepSelectedColumn() {
+    return this.editedStep.column;
+  }
+
+  set stepSelectedColumn(colname: string | null) {
+    if (colname === null) {
+      throw new Error('should not try to set null on "column" field');
+    }
+    this.editedStep.column = colname;
+  }
 }
 </script>

--- a/src/components/stepforms/ArgminStepForm.vue
+++ b/src/components/stepforms/ArgminStepForm.vue
@@ -14,7 +14,6 @@
       v-model="editedStep.groups"
       name="(Optional) Group by..."
       :options="columnNames"
-      @input="setSelectedColumns({ column: editedStep.groups[editedStep.groups.length-1] })"
       placeholder="Add columns"
       data-path=".groups"
       :errors="errors"
@@ -44,5 +43,16 @@ export default class ArgminStepForm extends BaseStepForm<ArgminStep> {
   initialStepValue!: ArgminStep;
 
   readonly title: string = 'Argmin';
+
+  get stepSelectedColumn() {
+    return this.editedStep.column;
+  }
+
+  set stepSelectedColumn(colname: string | null) {
+    if (colname === null) {
+      throw new Error('should not try to set null on "column" field');
+    }
+    this.editedStep.column = colname;
+  }
 }
 </script>


### PR DESCRIPTION
In `argmax`:

Bad labelling for `column` parameter ("min" instead of "max).

In `argmax` and `argmin`:

When choosing a column in the `groups` parameter, it selected the corresponding column, which in turn changed the value of the `column` parameter

Fixed bad initialization (when a column was selected before opening
the step form, the value of the ColumnPicker component was properly
initialized but editedStep was not)