### PR TITLE
[filter] fix shared references between conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Fixed `top` step initialization (`rank_on` parameter)
 - Fixed `argmin` and `argmax` labelling, initialization and interactions
+- Fixed shared references between items in List widget.
 
 ## [0.2.0] - 2010-09-26
 

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -26,6 +26,7 @@
 </template>
 
 <script lang="ts">
+import _ from 'lodash';
 import { Component, Prop, Vue, Mixins } from 'vue-property-decorator';
 import { VueConstructor } from 'vue';
 import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
@@ -97,7 +98,7 @@ export default class ListWidget extends Mixins(FormWidget) {
   }
 
   addFieldSet() {
-    this.updateValue([...this.value, this.defaultChildValue]);
+    this.updateValue([...this.value, _.cloneDeep(this.defaultChildValue)]);
   }
 
   removeChild(index: number) {

--- a/tests/unit/list-widget.spec.ts
+++ b/tests/unit/list-widget.spec.ts
@@ -1,6 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import ListWidget from '@/components/stepforms/widgets/List.vue';
 import AggregationWidget from '@/components/stepforms/widgets/Aggregation.vue';
+import FilterSimpleConditionWidget from '@/components/stepforms/widgets/FilterSimpleCondition.vue';
 
 describe('Widget List', () => {
   describe('automatic new field', () => {
@@ -93,6 +94,34 @@ describe('Widget List', () => {
 
       expect(wrapper.emitted()['input']).toBeDefined();
       expect(wrapper.emitted()['input'][0][0][0]).toEqual('');
+    });
+
+    it('should not share the same "default item" reference among list items', () => {
+      const wrapper = shallowMount(ListWidget, {
+        propsData: {
+          automaticNewField: false,
+          widget: FilterSimpleConditionWidget,
+          defaultItem: { column: '', value: '', operator: 'eq' },
+          name: 'Aggregation',
+        },
+      });
+      const addButtonWrapper = wrapper.find('button');
+      addButtonWrapper.trigger('click');
+      // 1. get back the emitted object
+      const emitted = wrapper.emitted()['input'][0][0][0];
+      expect(emitted).toEqual({
+        column: '',
+        value: '',
+        operator: 'eq',
+      });
+      // 2. modify it, next clicks should still the original item
+      emitted.value = '1';
+      addButtonWrapper.trigger('click');
+      expect(wrapper.emitted()['input'][1][0][0]).toEqual({
+        column: '',
+        value: '',
+        operator: 'eq',
+      });
     });
   });
 });


### PR DESCRIPTION
When a new field is added in the `List` widget, make sure to make
a (deep) copy of the default item otherwise we might just have several
items using references to the same object in memory.

closes #329