### PR TITLE
Feature :: split step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Added
 
 - Added concatenate step
+- Added split step
 
 ## [0.3.0] - 2010-10-08
 

--- a/doc/steps.md
+++ b/doc/steps.md
@@ -831,6 +831,90 @@ When sorting on several columns, order of columns specified in `columns` matters
 | Label 6 | Group 2 | 5     |
 | Label 4 | Group 2 | 1     |
 
+### `split` step
+
+Split a string `column` into several columns based on a `delimiter`.
+
+```javascript
+{
+  name: 'split',
+  column: 'foo', // the columnn to split
+  delimiter: ' - ', // the delimiter can e a strinng of any length
+  number_cols_to_keep: 3, // the numer of columns to keep resulting from the
+                          // split (starting from first chunk)
+}
+```
+
+#### Example 1
+
+**Input dataset:**
+
+| Label                      | Value |
+| -------------------------- | ----- |
+| Label 1 - Group 1 - France | 13    |
+| Label 2 - Group 1 - Spain  | 7     |
+| Label 3 - Group 1 - USA    | 20    |
+| Label 4 - Group 2 - France | 1     |
+| Label 5 - Group 2 - Spain  | 10    |
+| Label 6 - Group 2 - USA    | 5     |
+
+**Step configuration:**
+
+```javascript
+{
+  name: 'split',
+  column: 'Label',
+  delimiter: ' - ',
+  number_cols_to_keep: 3,
+}
+```
+
+**Output dataset:**
+
+| Label_1 | Label_2 | Label_3 | Value |
+| ------- | ------- | ------- | ----- |
+| Label 3 | Group 1 | France  | 20    |
+| Label 1 | Group 1 | Spain   | 13    |
+| Label 2 | Group 1 | USA     | 7     |
+| Label 5 | Group 2 | France  | 10    |
+| Label 6 | Group 2 | Spain   | 5     |
+| Label 4 | Group 2 | USA     | 1     |
+
+#### Example 2: keeping less columns
+
+**Input dataset:**
+
+| Label                      | Value |
+| -------------------------- | ----- |
+| Label 1 - Group 1 - France | 13    |
+| Label 2 - Group 1 - Spain  | 7     |
+| Label 3 - Group 1 - USA    | 20    |
+| Label 4 - Group 2 - France | 1     |
+| Label 5 - Group 2 - Spain  | 10    |
+| Label 6 - Group 2 - USA    | 5     |
+
+**Step configuration:**
+
+```javascript
+{
+  name: 'split',
+  column: 'Label',
+  delimiter: ' - ',
+  number_cols_to_keep: 2,
+}
+```
+
+**Output dataset:**
+
+| Label_1 | Label_2 | Value |
+| ------- | ------- | ----- |
+| Label 3 | Group 1 | 20    |
+| Label 1 | Group 1 | 13    |
+| Label 2 | Group 1 | 7     |
+| Label 5 | Group 2 | 10    |
+| Label 6 | Group 2 | 5     |
+| Label 4 | Group 2 | 1     |
+
 ### `top` step
 
 Return top N rows by group if `groups` is specified, else over full dataset.

--- a/src/components/constants.ts
+++ b/src/components/constants.ts
@@ -38,6 +38,7 @@ export const ACTION_CATEGORIES: ActionCategories = {
   ],
   text: [
     { name: 'concatenate', label: 'Concatenate' },
+    { name: 'split', label: 'Split column' },
     { name: 'lowercase', label: 'To lowercase' },
     { name: 'uppercase', label: 'To uppercase' },
   ],

--- a/src/components/stepforms/SplitStepForm.vue
+++ b/src/components/stepforms/SplitStepForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <step-form-title :title="title"></step-form-title>
+    <step-form-title :title="title"/>
     <ColumnPicker
       id="columnToSplit"
       v-model="editedStep.column"
@@ -8,7 +8,7 @@
       placeholder="Enter a column"
       data-path=".column"
       :errors="errors"
-    ></ColumnPicker>
+    />
     <InputTextWidget
       id="delimiter"
       v-model="editedStep.delimiter"
@@ -16,7 +16,7 @@
       placeholder="Enter a text delimiter"
       data-path=".delimiter"
       :errors="errors"
-    ></InputTextWidget>
+    />
     <InputTextWidget
       id="numberColsToKeep"
       v-model.number="editedStep.number_cols_to_keep"
@@ -25,8 +25,8 @@
       placeholder="Enter an integer"
       data-path=".number_cols_to_keep"
       :errors="errors"
-    ></InputTextWidget>
-    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+    />
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"/>
   </div>
 </template>
 

--- a/src/components/stepforms/SplitStepForm.vue
+++ b/src/components/stepforms/SplitStepForm.vue
@@ -1,0 +1,69 @@
+<template>
+  <div>
+    <step-form-title :title="title"></step-form-title>
+    <ColumnPicker
+      id="columnToSplit"
+      v-model="editedStep.column"
+      name="Split column..."
+      placeholder="Enter a column"
+      data-path=".column"
+      :errors="errors"
+    ></ColumnPicker>
+    <InputTextWidget
+      id="delimiter"
+      v-model="editedStep.delimiter"
+      name="Delimiter:"
+      placeholder="Enter a text delimiter"
+      data-path=".delimiter"
+      :errors="errors"
+    ></InputTextWidget>
+    <InputTextWidget
+      id="numberColsToKeep"
+      v-model.number="editedStep.number_cols_to_keep"
+      type="number"
+      name="Number of columns to keep:"
+      placeholder="Enter an integer"
+      data-path=".number_cols_to_keep"
+      :errors="errors"
+    ></InputTextWidget>
+    <step-form-buttonbar :cancel="cancelEdition" :submit="submit"></step-form-buttonbar>
+  </div>
+</template>
+
+<script lang="ts">
+import { Prop } from 'vue-property-decorator';
+import { SplitStep } from '@/lib/steps';
+import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
+import InputTextWidget from '@/components/stepforms/widgets/InputText.vue';
+import BaseStepForm from './StepForm.vue';
+import { StepFormComponent } from '@/components/formlib';
+
+@StepFormComponent({
+  vqbstep: 'split',
+  name: 'split-step-form',
+  components: {
+    ColumnPicker,
+    InputTextWidget,
+  },
+})
+export default class SplitStepForm extends BaseStepForm<SplitStep> {
+  @Prop({
+    type: Object,
+    default: () => ({ name: 'split', column: '', delimiter: '' }),
+  })
+  initialStepValue!: SplitStep;
+
+  readonly title: string = 'Split column';
+
+  get stepSelectedColumn() {
+    return this.editedStep.column;
+  }
+
+  set stepSelectedColumn(colname: string | null) {
+    if (colname === null) {
+      throw new Error('should not try to set null on "column" field');
+    }
+    this.editedStep.column = colname;
+  }
+}
+</script>

--- a/src/components/stepforms/index.ts
+++ b/src/components/stepforms/index.ts
@@ -13,6 +13,7 @@ import './PivotStepForm.vue';
 import './RenameStepForm.vue';
 import './ReplaceStepForm.vue';
 import './SelectColumnStepForm.vue';
+import './SplitStepForm.vue';
 import './ToLowerStepForm.vue';
 import './TopStepForm.vue';
 import './ToUpperStepForm.vue';

--- a/src/components/stepforms/schemas/index.ts
+++ b/src/components/stepforms/schemas/index.ts
@@ -14,6 +14,7 @@ import renameBuildSchema from './rename';
 import replaceSchema from './replace';
 import selectSchema from './select';
 import sortSchema from './sort';
+import splitSchema from './split';
 import toLowerSchema from './tolower';
 import topBuildSchema from './top';
 import toUpperSchema from './toupper';
@@ -39,6 +40,7 @@ const factories: { [stepname: string]: buildSchemaType } = {
   replace: replaceSchema,
   select: selectSchema,
   sort: sortSchema,
+  split: splitSchema,
   top: topBuildSchema,
   unpivot: unpivotSchema,
   uppercase: toUpperSchema,

--- a/src/components/stepforms/schemas/split.ts
+++ b/src/components/stepforms/schemas/split.ts
@@ -1,0 +1,39 @@
+export default {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Split step',
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      enum: ['split'],
+    },
+    column: {
+      type: 'string',
+      minLength: 1,
+      title: 'Split column...',
+      description: 'The column to split',
+      attrs: {
+        placeholder: 'Select a column',
+      },
+    },
+    delimiter: {
+      type: 'string',
+      title: 'Delimiter',
+      description: 'The delimiter used to split column',
+      attrs: {
+        placeholder: 'Enter a tet delimiter',
+      },
+      minLength: 1,
+    },
+    number_cols_to_keep: {
+      type: 'integer',
+      title: 'Number of columns to keep',
+      description: 'The number of columns to keep after splitting',
+      attrs: {
+        placeholder: 'Enter an integer',
+      },
+    },
+  },
+  required: ['column', 'delimiter', 'number_cols_to_keep'],
+  additionalProperties: false,
+};

--- a/src/lib/labeller.ts
+++ b/src/lib/labeller.ts
@@ -172,6 +172,10 @@ class StepLabeller implements StepMatcher<string> {
     return `Sort columns ${formatMulticol(columns)}`;
   }
 
+  split(step: Readonly<S.SplitStep>) {
+    return `Split column "${step.column}"`;
+  }
+
   top(step: Readonly<S.TopStep>) {
     return `Keep top ${step.limit} values in column "${step.rank_on}"`;
   }

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -151,6 +151,13 @@ export type SortStep = {
   columns: SortColumnType[];
 };
 
+export type SplitStep = {
+  name: 'split';
+  column: string;
+  delimiter: string;
+  number_cols_to_keep: number;
+};
+
 export type ToLowerStep = {
   name: 'lowercase';
   column: string;
@@ -195,6 +202,7 @@ export type PipelineStep =
   | RenameStep
   | ReplaceStep
   | SelectStep
+  | SplitStep
   | SortStep
   | ToLowerStep
   | TopStep

--- a/src/lib/templating.ts
+++ b/src/lib/templating.ts
@@ -202,6 +202,10 @@ export class PipelineInterpolator implements StepMatcher<S.PipelineStep> {
     return { ...step };
   }
 
+  split(step: Readonly<S.SplitStep>) {
+    return { ...step };
+  }
+
   top(step: Readonly<S.TopStep>) {
     return { ...step, limit: Number(_interpolate(this.interpolateFunc, step.limit, this.context)) };
   }

--- a/src/lib/translators/base.ts
+++ b/src/lib/translators/base.ts
@@ -145,6 +145,9 @@ export class BaseTranslator implements StepMatcher<OutputStep> {
   sort(step: Readonly<S.SortStep>) {}
 
   @unsupported
+  split(step: Readonly<S.SplitStep>) {}
+
+  @unsupported
   top(step: Readonly<S.TopStep>) {}
 
   @unsupported

--- a/tests/unit/action-toolbar-button.spec.ts
+++ b/tests/unit/action-toolbar-button.spec.ts
@@ -41,16 +41,19 @@ describe('ActionToolbar', () => {
     const wrapper = mount(ActionToolbarButton, { propsData: { category: 'text' } });
     expect(wrapper.exists()).toBeTruthy();
     const actionsWrappers = wrapper.findAll('.action-menu__option');
-    expect(actionsWrappers.length).toEqual(3);
+    expect(actionsWrappers.length).toEqual(4);
     actionsWrappers.at(0).trigger('click');
     expect(wrapper.emitted().actionClicked).toHaveLength(1);
     expect(wrapper.emitted().actionClicked[0]).toEqual(['concatenate']);
+    actionsWrappers.at(1).trigger('click');
+    expect(wrapper.emitted().actionClicked).toHaveLength(2);
+    expect(wrapper.emitted().actionClicked[1]).toEqual(['split']);
     // clicking on "lowercase" ou "uppercase" should not trigger "actionClicked"
     // since we don't use an edit form for these steps.
-    actionsWrappers.at(1).trigger('click');
-    expect(wrapper.emitted().actionClicked).toHaveLength(1);
     actionsWrappers.at(2).trigger('click');
-    expect(wrapper.emitted().actionClicked).toHaveLength(1);
+    expect(wrapper.emitted().actionClicked).toHaveLength(2);
+    actionsWrappers.at(3).trigger('click');
+    expect(wrapper.emitted().actionClicked).toHaveLength(2);
   });
 
   it('should instantiate a Date button with the right list of actions', () => {
@@ -90,7 +93,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(1).trigger('click');
+      await actionsWrappers.at(2).trigger('click');
       expect(store.state.vqb.currentStepFormName).toEqual(undefined);
     });
 
@@ -105,7 +108,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(1).trigger('click');
+      await actionsWrappers.at(2).trigger('click');
       expect(store.state.vqb.pipeline).toEqual([
         { name: 'domain', domain: 'myDomain' },
         { name: 'lowercase', column: 'foo' },
@@ -124,7 +127,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(1).trigger('click');
+      await actionsWrappers.at(2).trigger('click');
       expect(wrapper.emitted().closed).toBeTruthy();
     });
   });
@@ -141,7 +144,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(2).trigger('click');
+      await actionsWrappers.at(3).trigger('click');
       expect(store.state.vqb.currentStepFormName).toEqual(undefined);
     });
 
@@ -156,7 +159,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(2).trigger('click');
+      await actionsWrappers.at(3).trigger('click');
       expect(store.state.vqb.pipeline).toEqual([
         { name: 'domain', domain: 'myDomain' },
         { name: 'uppercase', column: 'foo' },
@@ -175,7 +178,7 @@ describe('ActionToolbar', () => {
         localVue,
       });
       const actionsWrappers = wrapper.findAll('.action-menu__option');
-      await actionsWrappers.at(2).trigger('click');
+      await actionsWrappers.at(3).trigger('click');
       expect(wrapper.emitted().closed).toBeTruthy();
     });
   });

--- a/tests/unit/labeller.spec.ts
+++ b/tests/unit/labeller.spec.ts
@@ -324,6 +324,16 @@ describe('Labeller', () => {
     expect(hrl(step)).toEqual('Sort columns "column1", "column2"');
   });
 
+  it('generates label for split steps', () => {
+    const step: S.SplitStep = {
+      name: 'split',
+      column: 'foo',
+      delimiter: '-',
+      number_cols_to_keep: 3,
+    };
+    expect(hrl(step)).toEqual('Split column "foo"');
+  });
+
   it('generates label for lowercase steps', () => {
     const step: S.ToLowerStep = {
       name: 'lowercase',

--- a/tests/unit/mongo.spec.ts
+++ b/tests/unit/mongo.spec.ts
@@ -1232,7 +1232,7 @@ describe('Pipeline to mongo translator', () => {
     expect(querySteps).toEqual([{ $addFields: { bar: '$foo' } }, { $project: { _id: 0 } }]);
   });
 
-  it('can generate an tolower', () => {
+  it('can generate a lowercase step', () => {
     const pipeline: Pipeline = [
       {
         name: 'lowercase',
@@ -1246,7 +1246,32 @@ describe('Pipeline to mongo translator', () => {
     ]);
   });
 
-  it('can generate an toupper', () => {
+  it('can generate a split step', () => {
+    const pipeline: Pipeline = [
+      {
+        name: 'split',
+        column: 'foo',
+        delimiter: ' - ',
+        number_cols_to_keep: 3,
+      },
+    ];
+    const querySteps = mongo36translator.translate(pipeline);
+    expect(querySteps).toEqual([
+      {
+        $addFields: { _vqbTmp: { $split: ['$foo', ' - '] } },
+      },
+      {
+        $addFields: {
+          foo_1: { $arrayElemAt: ['$_vqbTmp', 0] },
+          foo_2: { $arrayElemAt: ['$_vqbTmp', 1] },
+          foo_3: { $arrayElemAt: ['$_vqbTmp', 2] },
+        },
+      },
+      { $project: { _id: 0, _vqbTmp: 0 } },
+    ]);
+  });
+
+  it('can generate an uppercase step', () => {
     const pipeline: Pipeline = [
       {
         name: 'uppercase',

--- a/tests/unit/split-step-form.spec.ts
+++ b/tests/unit/split-step-form.spec.ts
@@ -1,0 +1,105 @@
+import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
+import SplitStepForm from '@/components/stepforms/SplitStepForm.vue';
+import Vuex, { Store } from 'vuex';
+import { setupMockStore } from './utils';
+import { Pipeline } from '@/lib/steps';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+interface ValidationError {
+  dataPath: string;
+  keyword: string;
+}
+
+describe('Split Step Form', () => {
+  let emptyStore: Store<any>;
+  beforeEach(() => {
+    emptyStore = setupMockStore({});
+  });
+
+  it('should instantiate', () => {
+    const wrapper = shallowMount(SplitStepForm, { store: emptyStore, localVue });
+    expect(wrapper.exists()).toBeTruthy();
+    expect(wrapper.vm.$data.stepname).toEqual('split');
+  });
+
+  it('should have exactly 3 input components', () => {
+    const wrapper = shallowMount(SplitStepForm, { store: emptyStore, localVue });
+    expect(wrapper.find('#columnToSplit').exists()).toBeTruthy();
+    expect(wrapper.find('#delimiter').exists()).toBeTruthy();
+    expect(wrapper.find('#numberColsToKeep').exists()).toBeTruthy();
+  });
+
+  it('should pass down the properties to the input components', async () => {
+    const wrapper = shallowMount(SplitStepForm, { store: emptyStore, localVue });
+    wrapper.setData({
+      editedStep: { name: 'split', column: 'foo', delimiter: '-', number_cols_to_keep: 3 },
+    });
+    await localVue.nextTick();
+    expect(wrapper.find('#delimiter').props('value')).toEqual('-');
+    expect(wrapper.find('#numberColsToKeep').props('value')).toEqual(3);
+  });
+
+  it('should report errors when column is empty', async () => {
+    const wrapper = mount(SplitStepForm, { store: emptyStore, localVue });
+    wrapper.find('.widget-form-action__button--validate').trigger('click');
+    await localVue.nextTick();
+    const errors = wrapper.vm.$data.errors
+      .map((err: ValidationError) => ({ keyword: err.keyword, dataPath: err.dataPath }))
+      .sort((err1: ValidationError, err2: ValidationError) =>
+        err1.dataPath.localeCompare(err2.dataPath),
+      );
+    expect(errors).toEqual([
+      { keyword: 'required', dataPath: '' },
+      { keyword: 'minLength', dataPath: '.column' },
+      { keyword: 'minLength', dataPath: '.delimiter' },
+    ]);
+  });
+
+  it('should validate and emit "formSaved" when submitted data is valid', async () => {
+    const wrapper = mount(SplitStepForm, {
+      store: emptyStore,
+      localVue,
+      sync: false,
+      propsData: {
+        initialStepValue: { name: 'split', column: 'foo', delimiter: '-', number_cols_to_keep: 3 },
+      },
+    });
+    wrapper.find('.widget-form-action__button--validate').trigger('click');
+    await localVue.nextTick();
+    expect(wrapper.vm.$data.errors).toBeNull();
+    expect(wrapper.emitted()).toEqual({
+      formSaved: [[{ name: 'split', column: 'foo', delimiter: '-', number_cols_to_keep: 3 }]],
+    });
+  });
+
+  it('should emit "cancel" event when edition is cancelled', async () => {
+    const wrapper = mount(SplitStepForm, { store: emptyStore, localVue });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    await localVue.nextTick();
+    expect(wrapper.emitted()).toEqual({
+      cancel: [[]],
+    });
+  });
+
+  it('should reset selectedStepIndex correctly on cancel depending on isStepCreation', () => {
+    const pipeline: Pipeline = [
+      { name: 'domain', domain: 'foo' },
+      { name: 'rename', oldname: 'foo', newname: 'bar' },
+      { name: 'rename', oldname: 'baz', newname: 'spam' },
+      { name: 'rename', oldname: 'tic', newname: 'tac' },
+    ];
+    const store: Store<any> = setupMockStore({
+      pipeline,
+      selectedStepIndex: 2,
+    });
+    const wrapper = mount(SplitStepForm, { store, localVue });
+    wrapper.setProps({ isStepCreation: true });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    expect(store.state.vqb.selectedStepIndex).toEqual(2);
+    wrapper.setProps({ isStepCreation: false });
+    wrapper.find('.widget-form-action__button--cancel').trigger('click');
+    expect(store.state.vqb.selectedStepIndex).toEqual(3);
+  });
+});

--- a/tests/unit/templating.spec.ts
+++ b/tests/unit/templating.spec.ts
@@ -737,6 +737,18 @@ describe('Pipeline interpolator', () => {
     expect(translate(pipeline)).toEqual(pipeline);
   });
 
+  it('should leave split steps untouched', () => {
+    const pipeline: Pipeline = [
+      {
+        name: 'split',
+        column: '<%= foo %>',
+        delimiter: '<%= delim %>',
+        number_cols_to_keep: 3,
+      },
+    ];
+    expect(translate(pipeline)).toEqual(pipeline);
+  });
+
   it('should leave top steps untouched if no variable is found', () => {
     const pipeline: Pipeline = [
       {


### PR DESCRIPTION
Introduce a `split` step translated into mongo.
Allows splitting a text column based on a delimiter. 

Closes https://github.com/ToucanToco/vue-query-builder/issues/339