### PR TITLE
feature :: add a separator label to filters form and fix form input wrong sizing

### DIFF
--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="filter-form">
+  <div class="filter-form" :class="multipleConditionsClass">
     <step-form-title :title="title"></step-form-title>
     <div class="filter-form-headers__container">
       <div class="filter-form-header">Values in...</div>
@@ -7,7 +7,7 @@
     </div>
     <ListWidget
       addFieldName="Add condition"
-      separatorLabel="And"
+      separatorLabel="and"
       id="filterConditions"
       v-model="conditions"
       :defaultItem="defaultCondition"
@@ -86,6 +86,12 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
     }
   }
 
+  get multipleConditionsClass() {
+    return {
+      'filter-form--multiple-conditions': this.conditions.length > 1,
+    }
+  }
+
   set conditions(newval) {
     if (isFilterComboAnd(this.editedStep.condition)) {
       this.editedStep.condition.and = [...newval];
@@ -122,7 +128,22 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
 }
 </style>
 <style lang="scss">
-.filter-form .widget-list__body .widget-list__icon {
-  top: 5px;
+.filter-form {
+  .widget-list__body .widget-list__icon {
+    top: 5px;
+  }
+  .widget-list__component-sep {
+    left: 0;
+    position: absolute;
+    top: 10px;
+  }
+}
+.filter-form--multiple-conditions {
+  .filter-form-headers__container {
+    margin-left: 30px;
+  }
+  .widget-list__component {
+    margin-left: 30px;
+  }
 }
 </style>

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -86,15 +86,15 @@ export default class FilterStepForm extends BaseStepForm<FilterStep> {
     }
   }
 
-  get multipleConditionsClass() {
-    return {
-      'filter-form--multiple-conditions': this.conditions.length > 1,
-    }
-  }
-
   set conditions(newval) {
     if (isFilterComboAnd(this.editedStep.condition)) {
       this.editedStep.condition.and = [...newval];
+    }
+  }
+
+  get multipleConditionsClass() {
+    return {
+      'filter-form--multiple-conditions': this.conditions.length > 1,
     }
   }
 

--- a/src/components/stepforms/FilterStepForm.vue
+++ b/src/components/stepforms/FilterStepForm.vue
@@ -7,6 +7,7 @@
     </div>
     <ListWidget
       addFieldName="Add condition"
+      separatorLabel="And"
       id="filterConditions"
       v-model="conditions"
       :defaultItem="defaultCondition"

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -161,6 +161,9 @@ export default class ListWidget extends Mixins(FormWidget) {
   background-color: #f8f8f8;
   width: 98%;
 }
+.widget-list__component-sep {
+  font-size: 14px;
+}
 
 .widget-list__add-fieldset {
   @extend %button-default;

--- a/src/components/stepforms/widgets/List.vue
+++ b/src/components/stepforms/widgets/List.vue
@@ -3,6 +3,10 @@
     <label :for="id">{{name}}</label>
     <div class="widget-list__body">
       <div class="widget-list__child" v-for="(child, index) in children" :key="index">
+        <span
+          class="widget-list__component-sep"
+          v-if="index > 0 && separatorLabel"
+        >{{ separatorLabel }}</span>
         <div class="widget-list__component">
           <component
             :is="widget"
@@ -53,6 +57,9 @@ export default class ListWidget extends Mixins(FormWidget) {
 
   @Prop({ type: String, default: '' })
   name!: string;
+
+  @Prop({ type: String, default: null })
+  separatorLabel!: string;
 
   @Prop({ type: Array, default: () => [] })
   value!: any[];

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -19,7 +19,11 @@ $grey-dark: #585858;
 .query-builder {
   color: $base-color;
   font-family: 'Montserrat', sans-serif;
-  box-sizing: border-box;
+  *,
+  ::after,
+  ::before {
+    box-sizing: border-box;
+  }
 
   button {
     outline: none;

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -24,6 +24,17 @@ describe('Filter Step Form', () => {
     expect(wrapper.vm.$data.stepname).toEqual('filter');
   });
 
+  it('should get a specific class when there is more than one condition to filter-form container', () => {
+    const wrapper = shallowMount(FilterStepForm, { store: emptyStore, localVue });
+    wrapper.setData({
+      editedStep: {
+        name: 'filter',
+        condition: { and: [{ column: 'foo', value: 'bar', operator: 'gt' }, { column: 'yolo', value: 'carpe diem', operator: 'nin' }] },
+      },
+    });
+    expect(wrapper.classes()).toContain('filter-form--multiple-conditions');
+  });
+
   describe('ListWidget', () => {
     it('should have exactly on ListWidget component', () => {
       const wrapper = shallowMount(FilterStepForm, { store: emptyStore, localVue });


### PR DESCRIPTION
- Fix the input width size issue by adding the border-box: box-sizing property to all element inside the classname `.data-viewer` and `.query-builder`scope.

- Add a label separator `and` between conditions with a specific style to have a better visual UI understanding : now when we add a condition we get an extra margin-left on all widget-list item.

results :
![image](https://user-images.githubusercontent.com/4438175/66325393-77896480-e927-11e9-93b0-8b2947e320bc.png)

