### PR TITLE
FIX :: add capture catching on click listener to fix closing popover widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## Fixed
+- Fixed closing popover on ActionButton when opening one on column header cell
+
 ## [0.3.0] - 2010-10-08
 
 ### Added

--- a/src/components/ActionMenu.vue
+++ b/src/components/ActionMenu.vue
@@ -92,9 +92,9 @@ export default class ActionMenu extends Vue {
   @Watch('isActive')
   onIsActiveChanged(val: boolean) {
     if (val) {
-      window.addEventListener('click', this.clickListener);
+      window.addEventListener('click', this.clickListener, { capture: true });
     } else {
-      window.removeEventListener('click', this.clickListener);
+      window.removeEventListener('click', this.clickListener, { capture: true });
     }
   }
 }

--- a/src/components/ActionToolbarButton.vue
+++ b/src/components/ActionToolbarButton.vue
@@ -51,8 +51,9 @@ export default class ActionToolbarButton extends Vue {
   /**
    * @description Close the popover when clicking outside
    */
-  clickListener(e: Event) {
-    const hasClickOnItSelf = e.target === this.$el || this.$el.contains(e.target as HTMLElement);
+  clickListener(e: Event ) {
+    const target = e.target as HTMLElement;
+    const hasClickOnItSelf = target === this.$el || this.$el.contains(target);
 
     if (!hasClickOnItSelf) {
       this.close();
@@ -76,9 +77,9 @@ export default class ActionToolbarButton extends Vue {
   @Watch('isActive')
   onIsActiveChanged(val: boolean) {
     if (val) {
-      window.addEventListener('click', this.clickListener);
+      window.addEventListener('click', this.clickListener, { capture: true });
     } else {
-      window.removeEventListener('click', this.clickListener);
+      window.removeEventListener('click', this.clickListener, { capture: true });
     }
   }
 }


### PR DESCRIPTION
Fix the closing issue on widget popover menu on click on column header menu by adding a capture event on click listener.

Closes https://github.com/ToucanToco/vue-query-builder/issues/346