### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Added
 
 - Added variable interpolation + autocast handling
+- Added `lowercase`step
+- Added `uppercase`step
 
 ### Changed
 


### PR DESCRIPTION
Add `lowercase` and `uppercase` steps that were part of release v0.3.0