### PR TITLE
[tests] narrow return signature of setupMockStore

### DIFF
--- a/tests/unit/action-menu.spec.ts
+++ b/tests/unit/action-menu.spec.ts
@@ -1,6 +1,6 @@
 import { mount, createLocalVue, shallowMount } from '@vue/test-utils';
 import ActionMenu from '@/components/ActionMenu.vue';
-import Vuex, { Store } from 'vuex';
+import Vuex from 'vuex';
 import { VQBnamespace } from '@/store';
 import { setupMockStore } from './utils';
 
@@ -84,7 +84,7 @@ describe('Action Menu', () => {
 
   describe('when clicking on "Delete column"', () => {
     it('should add a valide delete step in the pipeline', async () => {
-      const store: Store<any> = setupMockStore();
+      const store = setupMockStore();
       const wrapper = shallowMount(ActionMenu, {
         store,
         localVue,

--- a/tests/unit/action-toolbar-button.spec.ts
+++ b/tests/unit/action-toolbar-button.spec.ts
@@ -1,6 +1,6 @@
 import { mount, createLocalVue } from '@vue/test-utils';
 import ActionToolbarButton from '@/components/ActionToolbarButton.vue';
-import Vuex, { Store } from 'vuex';
+import Vuex from 'vuex';
 import { setupMockStore } from './utils';
 
 const localVue = createLocalVue();
@@ -83,7 +83,7 @@ describe('ActionToolbar', () => {
 
   describe('When clicking on the "To lowercase" operation', () => {
     it('should close any open step form', async () => {
-      const store: Store<any> = setupMockStore({
+      const store = setupMockStore({
         pipeline: [{ name: 'domain', domain: 'myDomain' }],
         selectedColumns: ['foo'],
       });
@@ -98,7 +98,7 @@ describe('ActionToolbar', () => {
     });
 
     it('should insert a lowercase step in pipeline', async () => {
-      const store: Store<any> = setupMockStore({
+      const store = setupMockStore({
         pipeline: [{ name: 'domain', domain: 'myDomain' }],
         selectedColumns: ['foo'],
       });
@@ -117,7 +117,7 @@ describe('ActionToolbar', () => {
     });
 
     it('should emit a close event', async () => {
-      const store: Store<any> = setupMockStore({
+      const store = setupMockStore({
         pipeline: [{ name: 'domain', domain: 'myDomain' }],
         selectedColumns: ['foo'],
       });
@@ -134,7 +134,7 @@ describe('ActionToolbar', () => {
 
   describe('When clicking on the "To uppercase" operation', () => {
     it('should close any open step form', async () => {
-      const store: Store<any> = setupMockStore({
+      const store = setupMockStore({
         pipeline: [{ name: 'domain', domain: 'myDomain' }],
         selectedColumns: ['foo'],
       });
@@ -149,7 +149,7 @@ describe('ActionToolbar', () => {
     });
 
     it('should insert a lowercase step in pipeline', async () => {
-      const store: Store<any> = setupMockStore({
+      const store = setupMockStore({
         pipeline: [{ name: 'domain', domain: 'myDomain' }],
         selectedColumns: ['foo'],
       });
@@ -168,7 +168,7 @@ describe('ActionToolbar', () => {
     });
 
     it('should emit a close event', async () => {
-      const store: Store<any> = setupMockStore({
+      const store = setupMockStore({
         pipeline: [{ name: 'domain', domain: 'myDomain' }],
         selectedColumns: ['foo'],
       });

--- a/tests/unit/aggregate-step-form.spec.ts
+++ b/tests/unit/aggregate-step-form.spec.ts
@@ -3,7 +3,7 @@ import AggregateStepForm from '@/components/stepforms/AggregateStepForm.vue';
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -15,7 +15,7 @@ interface ValidationError {
 }
 
 describe('Aggregate Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore();
   });
@@ -252,7 +252,7 @@ describe('Aggregate Step Form', () => {
   });
 
   it('should change the column focus after input in multiselect', async () => {
-    const store: Store<any> = setupMockStore({ selectedColumns: [] });
+    const store = setupMockStore({ selectedColumns: [] });
     const wrapper = mount(AggregateStepForm, { store, localVue, sync: false });
     wrapper.setData({ editedStep: { name: 'aggregate', on: ['foo'], aggregations: [] } });
     wrapper.find(MultiselectWidget).trigger('input');
@@ -267,7 +267,7 @@ describe('Aggregate Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/aggregation-widget.spec.ts
+++ b/tests/unit/aggregation-widget.spec.ts
@@ -1,13 +1,13 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import AggregationWidget from '@/components/stepforms/widgets/Aggregation.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Widget AggregationWidget', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });

--- a/tests/unit/argmax-step-form.spec.ts
+++ b/tests/unit/argmax-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import ArgmaxStepForm from '@/components/stepforms/ArgmaxStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -13,7 +13,7 @@ interface ValidationError {
 }
 
 describe('Argmax Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -85,7 +85,7 @@ describe('Argmax Step Form', () => {
       { name: 'argmax', column: 'baz' },
       { name: 'argmax', column: 'tic' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/argmin-step-form.spec.ts
+++ b/tests/unit/argmin-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import ArgminStepForm from '@/components/stepforms/ArgminStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -13,7 +13,7 @@ interface ValidationError {
 }
 
 describe('Argmin Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -85,7 +85,7 @@ describe('Argmin Step Form', () => {
       { name: 'argmin', column: 'baz' },
       { name: 'argmin', column: 'tic' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/column-picker.spec.ts
+++ b/tests/unit/column-picker.spec.ts
@@ -1,14 +1,14 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import ColumnPicker from '@/components/stepforms/ColumnPicker.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { VQBnamespace } from '@/store';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Column Picker', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -24,7 +24,7 @@ describe('Column Picker', () => {
   });
 
   it('should instantiate an autocomplete widget with proper options from the store', () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
@@ -36,7 +36,7 @@ describe('Column Picker', () => {
   });
 
   it('should set column when initialColumn is set', () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
@@ -53,7 +53,7 @@ describe('Column Picker', () => {
   });
 
   it('should update step when selectedColumn is changed by default', async () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
@@ -72,7 +72,7 @@ describe('Column Picker', () => {
   });
 
   it('should not update step when selectedColumn is changed if prop "sync" is false', async () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],

--- a/tests/unit/concatenate-step-form.spec.ts
+++ b/tests/unit/concatenate-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import ConcatenateStepForm from '@/components/stepforms/ConcatenateStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -13,7 +13,7 @@ interface ValidationError {
 }
 
 describe('Concatenate Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -119,7 +119,7 @@ describe('Concatenate Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/delete-column-step-form.spec.ts
+++ b/tests/unit/delete-column-step-form.spec.ts
@@ -2,7 +2,7 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import DeleteColumnStepForm from '@/components/stepforms/DeleteColumnStepForm.vue';
 import MultiselectWidget from '@/components/stepforms/widgets/Multiselect.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -14,7 +14,7 @@ interface ValidationError {
 }
 
 describe('Delete Column Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -74,7 +74,7 @@ describe('Delete Column Step Form', () => {
       { name: 'domain', domain: 'foo' },
       { name: 'rename', oldname: 'foo', newname: 'bar' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 1,
     });
@@ -90,7 +90,7 @@ describe('Delete Column Step Form', () => {
   });
 
   it('should update selectedColumn when column is changed', async () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
@@ -118,7 +118,7 @@ describe('Delete Column Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/domain-step-form.spec.ts
+++ b/tests/unit/domain-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import DomainStepForm from '@/components/stepforms/DomainStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -12,7 +12,7 @@ interface ValidationError {
 }
 
 describe('Domain Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });

--- a/tests/unit/duplicate-column-step-form.spec.ts
+++ b/tests/unit/duplicate-column-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import DuplicateColumnStepForm from '@/components/stepforms/DuplicateColumnStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -13,7 +13,7 @@ interface ValidationError {
 }
 
 describe('Duplicate Column Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -92,7 +92,7 @@ describe('Duplicate Column Step Form', () => {
       { name: 'domain', domain: 'foo' },
       { name: 'rename', oldname: 'foo', newname: 'bar' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 1,
     });
@@ -114,7 +114,7 @@ describe('Duplicate Column Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/fillna-step-form.spec.ts
+++ b/tests/unit/fillna-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import FillnaStepForm from '@/components/stepforms/FillnaStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 import { VQBnamespace } from '@/store';
 
@@ -14,7 +14,7 @@ interface ValidationError {
 }
 
 describe('Fillna Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -221,7 +221,7 @@ describe('Fillna Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });
@@ -235,7 +235,7 @@ describe('Fillna Step Form', () => {
   });
 
   it('should keep the focus on the column modified after rename validation', async () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],

--- a/tests/unit/filter-simple-condition-widget.spec.ts
+++ b/tests/unit/filter-simple-condition-widget.spec.ts
@@ -3,13 +3,13 @@ import FilterSimpleConditionWidget from '@/components/stepforms/widgets/FilterSi
 import AutocompleteWidget from '@/components/stepforms/widgets/Autocomplete.vue';
 import MultiInputTextWidget from '@/components/stepforms/widgets/MultiInputText.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Widget AggregationWidget', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -88,7 +88,7 @@ describe('Widget AggregationWidget', () => {
   });
 
   it('should update selectedColumn when column is changed', async () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],

--- a/tests/unit/filter-step-form.spec.ts
+++ b/tests/unit/filter-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import FilterStepForm from '@/components/stepforms/FilterStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -13,7 +13,7 @@ interface ValidationError {
 }
 
 describe('Filter Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -29,7 +29,12 @@ describe('Filter Step Form', () => {
     wrapper.setData({
       editedStep: {
         name: 'filter',
-        condition: { and: [{ column: 'foo', value: 'bar', operator: 'gt' }, { column: 'yolo', value: 'carpe diem', operator: 'nin' }] },
+        condition: {
+          and: [
+            { column: 'foo', value: 'bar', operator: 'gt' },
+            { column: 'yolo', value: 'carpe diem', operator: 'nin' },
+          ],
+        },
       },
     });
     expect(wrapper.classes()).toContain('filter-form--multiple-conditions');
@@ -325,7 +330,7 @@ describe('Filter Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/formula-step-form.spec.ts
+++ b/tests/unit/formula-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import FormulaStepForm from '@/components/stepforms/FormulaStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -13,7 +13,7 @@ interface ValidationError {
 }
 
 describe('Rename Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -117,7 +117,7 @@ describe('Rename Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });
@@ -131,7 +131,7 @@ describe('Rename Step Form', () => {
   });
 
   it('should make the focus on the column modified after validation', () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
@@ -144,7 +144,7 @@ describe('Rename Step Form', () => {
   });
 
   it('should not change the column focus if validation fails', () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],

--- a/tests/unit/percentage-step-form.spec.ts
+++ b/tests/unit/percentage-step-form.spec.ts
@@ -2,7 +2,7 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import PercentageStepForm from '@/components/stepforms/PercentageStepForm.vue';
 import Vuex, { Store } from 'vuex';
 import { VQBnamespace } from '@/store';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -14,7 +14,7 @@ interface ValidationError {
 }
 
 describe('Percentage Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -88,7 +88,7 @@ describe('Percentage Step Form', () => {
       { name: 'percentage', column: 'baz' },
       { name: 'percentage', column: 'tic' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/pivot-step-form.spec.ts
+++ b/tests/unit/pivot-step-form.spec.ts
@@ -2,7 +2,7 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import PivotStepForm from '@/components/stepforms/PivotStepForm.vue';
 import Vuex, { Store } from 'vuex';
 import { VQBnamespace } from '@/store';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -14,7 +14,7 @@ interface ValidationError {
 }
 
 describe('Pivot Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });

--- a/tests/unit/plugins.spec.ts
+++ b/tests/unit/plugins.spec.ts
@@ -46,7 +46,7 @@ describe('backend service plugin tests', () => {
       { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
       { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
     ];
-    const store: Store<any> = setupMockStore({ pipeline }, [
+    const store = setupMockStore({ pipeline }, [
       servicePluginFactory(new DummyService()),
     ]);
     const wrapper = mount(PipelineComponent, { store, localVue });
@@ -65,7 +65,7 @@ describe('backend service plugin tests', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore(
+    const store = setupMockStore(
       {
         pipeline,
         selectedStepIndex: 1,
@@ -81,7 +81,7 @@ describe('backend service plugin tests', () => {
   });
 
   it('should call execute pipeline when a setCurrentDomain mutation is committed', async () => {
-    const store: Store<any> = setupMockStore({}, [servicePluginFactory(new DummyService())]);
+    const store = setupMockStore({}, [servicePluginFactory(new DummyService())]);
     store.commit(VQBnamespace('setCurrentDomain'), { currentDomain: 'GoT' });
     await flushPromises();
     expect(store.state.vqb.dataset).toEqual({
@@ -96,7 +96,7 @@ describe('backend service plugin tests', () => {
       { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
       { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
     ];
-    const store: Store<any> = setupMockStore({ pipeline }, [
+    const store = setupMockStore({ pipeline }, [
       servicePluginFactory(new DummyService()),
     ]);
     store.commit(VQBnamespace('deleteStep'), { index: 2 });
@@ -108,7 +108,7 @@ describe('backend service plugin tests', () => {
   });
 
   it('should call execute pipeline with correct pagesize', async () => {
-    const store: Store<any> = setupMockStore({ pagesize: 1 }, [
+    const store = setupMockStore({ pagesize: 1 }, [
       servicePluginFactory(new DummyService()),
     ]);
     store.commit(VQBnamespace('setCurrentDomain'), { currentDomain: 'GoT' });
@@ -130,7 +130,7 @@ describe('backend service plugin tests', () => {
         to_replace: [['<%= who %>', '<%= what %>']],
       },
     ];
-    const store: Store<any> = setupMockStore(
+    const store = setupMockStore(
       {
         pipeline,
         variables: {
@@ -165,7 +165,7 @@ describe('backend service plugin tests', () => {
         to_replace: [['<%= who %>', '<%= what %>']],
       },
     ];
-    const store: Store<any> = setupMockStore(
+    const store = setupMockStore(
       {
         pipeline,
         variables: {},

--- a/tests/unit/rename-step-form.spec.ts
+++ b/tests/unit/rename-step-form.spec.ts
@@ -2,7 +2,7 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import RenameStepForm from '@/components/stepforms/RenameStepForm.vue';
 import Vuex, { Store } from 'vuex';
 import { VQBnamespace } from '@/store';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -14,7 +14,7 @@ interface ValidationError {
 }
 
 describe('Rename Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -127,7 +127,7 @@ describe('Rename Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });
@@ -141,7 +141,7 @@ describe('Rename Step Form', () => {
   });
 
   it('should make the focus on the column modified after rename validation', () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
@@ -154,7 +154,7 @@ describe('Rename Step Form', () => {
   });
 
   it('should not change the column focus if validation fails', () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],

--- a/tests/unit/replace-step-form.spec.ts
+++ b/tests/unit/replace-step-form.spec.ts
@@ -2,13 +2,13 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import ReplaceStepForm from '@/components/stepforms/ReplaceStepForm.vue';
 import Vuex, { Store } from 'vuex';
 import { Pipeline } from '@/lib/steps';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Replace Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -218,7 +218,7 @@ describe('Replace Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/replace-widget.spec.ts
+++ b/tests/unit/replace-widget.spec.ts
@@ -1,13 +1,13 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import ReplaceWidget from '@/components/stepforms/widgets/Replace.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Widget ReplaceWidget', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });

--- a/tests/unit/select-column-step-form.spec.ts
+++ b/tests/unit/select-column-step-form.spec.ts
@@ -74,7 +74,7 @@ describe('Select Column Step Form', () => {
       { name: 'domain', domain: 'foo' },
       { name: 'rename', oldname: 'foo', newname: 'bar' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 1,
     });
@@ -90,7 +90,7 @@ describe('Select Column Step Form', () => {
   });
 
   it('should update selectedColumn when column is changed', async () => {
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       dataset: {
         headers: [{ name: 'columnA' }, { name: 'columnB' }, { name: 'columnC' }],
         data: [],
@@ -118,7 +118,7 @@ describe('Select Column Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/sort-column-widget.spec.ts
+++ b/tests/unit/sort-column-widget.spec.ts
@@ -1,13 +1,13 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import SortColumnWidget from '@/components/stepforms/widgets/SortColumn.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('Widget sort column', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });

--- a/tests/unit/sort-step-form.spec.ts
+++ b/tests/unit/sort-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import SortStepForm from '@/components/stepforms/SortStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -13,7 +13,7 @@ interface ValidationError {
 }
 
 describe('Sort Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -114,7 +114,7 @@ describe('Sort Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/split-step-form.spec.ts
+++ b/tests/unit/split-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import SplitStepForm from '@/components/stepforms/SplitStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 
 const localVue = createLocalVue();
@@ -13,7 +13,7 @@ interface ValidationError {
 }
 
 describe('Split Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -90,7 +90,7 @@ describe('Split Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/step.spec.ts
+++ b/tests/unit/step.spec.ts
@@ -1,5 +1,5 @@
 import { mount, createLocalVue, shallowMount } from '@vue/test-utils';
-import Vuex, { Store } from 'vuex';
+import Vuex from 'vuex';
 import { Pipeline } from '@/lib/steps';
 import { setupMockStore } from './utils';
 import DeleteConfirmationModal from '@/components/DeleteConfirmationModal.vue';
@@ -122,7 +122,7 @@ describe('Step.vue', () => {
         { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
         { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
       ];
-      const store: Store<any> = setupMockStore({ pipeline });
+      const store = setupMockStore({ pipeline });
       const wrapper = mount(PipelineComponent, { store, localVue });
       const step = wrapper.findAll(Step).at(1);
 
@@ -151,7 +151,7 @@ describe('Step.vue', () => {
         { name: 'replace', search_column: 'characters', to_replace: [['Snow', 'Targaryen']] },
         { name: 'sort', columns: [{ column: 'death', order: 'asc' }] },
       ];
-      const store: Store<any> = setupMockStore({ pipeline });
+      const store = setupMockStore({ pipeline });
       const wrapper = mount(PipelineComponent, { store, localVue });
       const step = wrapper.findAll(Step).at(1);
       step.find('.fa-trash-alt').trigger('click');

--- a/tests/unit/tolower-step-form.spec.ts
+++ b/tests/unit/tolower-step-form.spec.ts
@@ -1,13 +1,13 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import ToLowerStepForm from '@/components/stepforms/ToLowerStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('To Uppercase Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });

--- a/tests/unit/top-step-form.spec.ts
+++ b/tests/unit/top-step-form.spec.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import TopStepForm from '@/components/stepforms/TopStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 import { ScopeContext } from '@/lib/templating';
 
@@ -15,7 +15,7 @@ interface ValidationError {
 }
 
 describe('Top Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -125,7 +125,7 @@ describe('Top Step Form', () => {
       { name: 'top', rank_on: 'bar', sort: 'asc', limit: 5 },
       { name: 'top', rank_on: 'tic', sort: 'desc', limit: 1 },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/toupper-step-form.spec.ts
+++ b/tests/unit/toupper-step-form.spec.ts
@@ -1,13 +1,13 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import ToUpperStepForm from '@/components/stepforms/ToUpperStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
 describe('To Uppercase Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });

--- a/tests/unit/unpivot-step-form.spec.ts
+++ b/tests/unit/unpivot-step-form.spec.ts
@@ -1,7 +1,7 @@
 import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import UnpivotStepForm from '@/components/stepforms/UnpivotStepForm.vue';
 import Vuex, { Store } from 'vuex';
-import { setupMockStore } from './utils';
+import { setupMockStore, RootState } from './utils';
 import { Pipeline } from '@/lib/steps';
 import CheckboxWidget from '@/components/stepforms/widgets/Checkbox.vue';
 
@@ -15,7 +15,7 @@ interface ValidationError {
 }
 
 describe('Unpivot Step Form', () => {
-  let emptyStore: Store<any>;
+  let emptyStore: Store<RootState>;
   beforeEach(() => {
     emptyStore = setupMockStore({});
   });
@@ -137,7 +137,7 @@ describe('Unpivot Step Form', () => {
       { name: 'rename', oldname: 'baz', newname: 'spam' },
       { name: 'rename', oldname: 'tic', newname: 'tac' },
     ];
-    const store: Store<any> = setupMockStore({
+    const store = setupMockStore({
       pipeline,
       selectedStepIndex: 2,
     });

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -1,8 +1,14 @@
-import Vuex from 'vuex';
+import Vuex, { Store } from 'vuex';
 import { registerModule } from '@/store';
 
+import { VQBState } from '@/store/state';
+
+export type RootState = {
+  vqb: VQBState;
+};
+
 export function setupMockStore(initialState: object = {}, plugins: any[] = []) {
-  const store = new Vuex.Store({ plugins });
+  const store: Store<RootState> = new Vuex.Store({ plugins });
   registerModule(store, initialState);
 
   return store;


### PR DESCRIPTION
Now, `setupMockStore` returns a `Store<RootState>` object where `RootState` is
an object with a `vqb` property that references a `VQBState`. `RootState` type
mimics a `VQBState` wrapped in a "vqb" namespace.

Now that this return signature is known by TypeScript, there is no need anymore to
associate a `Store<any>` type annotation when calling `setupMockStore`. Furtermore,
the remaining explicit `Store<any>` type annotations can now be replaced by a more
precise `Store<RootState>` one.